### PR TITLE
Extract the stale subscription cleaning in library code

### DIFF
--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -3,6 +3,7 @@
 require "graphql"
 
 require_relative "graphql/anycable/version"
+require_relative "graphql/anycable/cleaner"
 require_relative "graphql/anycable/config"
 require_relative "graphql/anycable/railtie" if defined?(Rails)
 require_relative "graphql/subscriptions/anycable_subscriptions"

--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -22,5 +22,13 @@ module GraphQL
         ::AnyCable.broadcast_adapter.redis_conn
       end
     end
+
+    def config
+      @config ||= GraphQL::Anycable::Config.new
+    end
+
+    def configure
+      yield(config) if block_given?
+    end
   end
 end

--- a/lib/graphql/anycable/cleaner.rb
+++ b/lib/graphql/anycable/cleaner.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Anycable
+    module Cleaner
+      extend self
+
+      def clean(subscription_expiration_seconds, use_redis_object_on_cleanup: true)
+        clean_channels(subscription_expiration_seconds, use_redis_object_on_cleanup: use_redis_object_on_cleanup)
+        clean_subscriptions(subscription_expiration_seconds, use_redis_object_on_cleanup: use_redis_object_on_cleanup)
+        clean_events
+      end
+
+      def clean_channels(subscription_expiration_seconds, use_redis_object_on_cleanup: true)
+        return unless subscription_expiration_seconds
+        return unless use_redis_object_on_cleanup
+
+        redis.scan_each(match: "#{adapter::CHANNEL_PREFIX}*") do |key|
+          idle = redis.object("IDLETIME", key)
+          next if idle&.<= subscription_expiration_seconds
+
+          redis.del(key)
+        end
+      end
+
+      def clean_subscriptions(subscription_expiration_seconds, use_redis_object_on_cleanup: true)
+        return unless subscription_expiration_seconds
+        return unless use_redis_object_on_cleanup
+
+        redis.scan_each(match: "#{adapter::SUBSCRIPTION_PREFIX}*") do |key|
+          idle = redis.object("IDLETIME", key)
+          next if idle&.<= subscription_expiration_seconds
+
+          redis.del(key)
+        end
+      end
+
+      def clean_events
+        redis.scan_each(match: "#{adapter::SUBSCRIPTION_EVENTS_PREFIX}*") do |key|
+          subscription_id = key.sub(/\A#{adapter::SUBSCRIPTION_EVENTS_PREFIX}/, "")
+          next if redis.exists(adapter::SUBSCRIPTION_PREFIX + subscription_id)
+
+          redis.smembers(key).each do |event_topic|
+            redis.srem(adapter::EVENT_PREFIX + event_topic, subscription_id)
+          end
+
+          redis.del(key)
+        end
+      end
+
+      private
+
+      def adapter
+        GraphQL::Subscriptions::AnyCableSubscriptions
+      end
+
+      def redis
+        GraphQL::Anycable.redis
+      end
+    end
+  end
+end

--- a/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
+++ b/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
@@ -1,6 +1,6 @@
-require "graphql-anycable"
-
 # frozen_string_literal: true
+
+require "graphql-anycable"
 
 namespace :graphql do
   namespace :anycable do
@@ -11,54 +11,30 @@ namespace :graphql do
     task clean_expired_subscriptions: :clean
 
     namespace :clean do
-      KLASS = GraphQL::Subscriptions::AnyCableSubscriptions
-
       # Clean up old channels
       task :channels do
-        next unless config.subscription_expiration_seconds
-        next unless config.use_redis_object_on_cleanup
-
-        redis.scan_each(match: "#{KLASS::CHANNEL_PREFIX}*") do |key|
-          idle = redis.object("IDLETIME", key)
-          next if idle&.<= config.subscription_expiration_seconds
-
-          redis.del(key)
-        end
+        GraphQL::Anycable::Cleaner.clean_channels(
+          config.subscription_expiration_seconds,
+          use_redis_object_on_cleanup: config.use_redis_object_on_cleanup
+        )
       end
 
       # Clean up old subscriptions (they should have expired by themselves)
       task :subscriptions do
-        next unless config.subscription_expiration_seconds
-        next unless config.use_redis_object_on_cleanup
-
-        redis.scan_each(match: "#{KLASS::SUBSCRIPTION_PREFIX}*") do |key|
-          idle = redis.object("IDLETIME", key)
-          next if idle&.<= config.subscription_expiration_seconds
-
-          redis.del(key)
-        end
+        GraphQL::Anycable::Cleaner.clean_subscriptions(
+          config.subscription_expiration_seconds,
+          use_redis_object_on_cleanup: config.use_redis_object_on_cleanup
+        )
       end
 
       # Clean up subscription_ids from events for expired subscriptions
       task :events do
-        redis.scan_each(match: "#{KLASS::SUBSCRIPTION_EVENTS_PREFIX}*") do |key|
-          subscription_id = key.sub(/\A#{KLASS::SUBSCRIPTION_EVENTS_PREFIX}/, "")
-          next if redis.exists(KLASS::SUBSCRIPTION_PREFIX + subscription_id)
-
-          redis.smembers(key).each do |event_topic|
-            redis.srem(KLASS::EVENT_PREFIX + event_topic, subscription_id)
-          end
-          redis.del(key)
-        end
+        GraphQL::Anycable::Cleaner.clean_events
       end
     end
 
     def config
       @config ||= GraphQL::Anycable::Config.new
-    end
-
-    def redis
-      GraphQL::Anycable.redis
     end
   end
 end

--- a/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
+++ b/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
@@ -13,28 +13,18 @@ namespace :graphql do
     namespace :clean do
       # Clean up old channels
       task :channels do
-        GraphQL::Anycable::Cleaner.clean_channels(
-          config.subscription_expiration_seconds,
-          use_redis_object_on_cleanup: config.use_redis_object_on_cleanup
-        )
+        GraphQL::Anycable::Cleaner.clean_channels
       end
 
       # Clean up old subscriptions (they should have expired by themselves)
       task :subscriptions do
-        GraphQL::Anycable::Cleaner.clean_subscriptions(
-          config.subscription_expiration_seconds,
-          use_redis_object_on_cleanup: config.use_redis_object_on_cleanup
-        )
+        GraphQL::Anycable::Cleaner.clean_subscriptions
       end
 
       # Clean up subscription_ids from events for expired subscriptions
       task :events do
         GraphQL::Anycable::Cleaner.clean_events
       end
-    end
-
-    def config
-      @config ||= GraphQL::Anycable::Config.new
     end
   end
 end

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -54,7 +54,7 @@ module GraphQL
     class AnyCableSubscriptions < GraphQL::Subscriptions
       extend Forwardable
 
-      def_delegators :"GraphQL::Anycable", :redis
+      def_delegators :"GraphQL::Anycable", :redis, :config
 
       SUBSCRIPTION_PREFIX = "graphql-subscription:"
       SUBSCRIPTION_EVENTS_PREFIX = "graphql-subscription-events:"
@@ -79,7 +79,7 @@ module GraphQL
       # This subscription was re-evaluated.
       # Send it to the specific stream where this client was waiting.
       def deliver(subscription_id, result)
-        payload = { result: result.to_h, more: true }
+        payload = {result: result.to_h, more: true}
         anycable.broadcast(SUBSCRIPTION_PREFIX + subscription_id, payload.to_json)
       end
 
@@ -95,7 +95,7 @@ module GraphQL
           query_string: query.query_string,
           variables: query.provided_variables.to_json,
           context: @serializer.dump(context.to_h),
-          operation_name: query.operation_name,
+          operation_name: query.operation_name
         }
 
         redis.multi do
@@ -115,9 +115,9 @@ module GraphQL
       def read_subscription(subscription_id)
         redis.mapped_hmget(
           "#{SUBSCRIPTION_PREFIX}#{subscription_id}",
-          :query_string, :variables, :context, :operation_name,
+          :query_string, :variables, :context, :operation_name
         ).tap do |subscription|
-          subscription[:context]   = @serializer.load(subscription[:context])
+          subscription[:context] = @serializer.load(subscription[:context])
           subscription[:variables] = JSON.parse(subscription[:variables])
           subscription[:operation_name] = nil if subscription[:operation_name].strip == ""
         end
@@ -146,10 +146,6 @@ module GraphQL
 
       def anycable
         @anycable ||= ::AnyCable.broadcast_adapter
-      end
-
-      def config
-        @config ||= GraphQL::Anycable::Config.new
       end
     end
   end


### PR DESCRIPTION
At Receipt Bank, we're using GraphQL Subscriptions with `graphql-anycable`, but we cannot easily execute rake tasks as periodical jobs and we had to copy-paste the rake task code into a job we can call. It would be way easier for setups like ours if we can invoke the cleaning process through plain Ruby code. This is where `GraphQL::Anycable::Cleaner.clean` comes in. If we can execute this in our periodic job, everything will be way easier.

Another aspect that is problematic for us is the configuration that is currently limited only to environment variables, as we're not keeping a "global" anyway config object reference, but instantiating it when needed and this supports configuration only through ENV variables, as far as I understand `Anyway`.

Having a global `GraphQL::Anyway.config`  (and the syntax sugar of `GraphQL::Anyway.configure`) will help us avoid monkey patches we have to `graphql-anycable` to share a global config for `subscription_expiration_seconds` we set through our custom configuration management solution.

What do you think about those changes? I haven't figured out a simple way to unit-test the changes, but have tested them against a fork of our app and seem to work.