### PR TITLE
GraphQL-Ruby 1.11+ Broadcasting feature support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.0.0 - 2021-04-01
+
+### Added
+
+ - Support for [Subscriptions Broadcast](https://graphql-ruby.org/subscriptions/broadcast.html) feature in GraphQL-Ruby 1.11+. [@Envek] ([#15](https://github.com/anycable/graphql-anycable/pull/15))
+
+### Changed
+
+ - Subscription data storage format changed to support broadcasting feature (see [#15](https://github.com/anycable/graphql-anycable/pull/15))
+
 ### Removed
 
  - Drop support for GraphQL-Ruby before 1.11
@@ -16,6 +26,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Drop `:action_cable_stream` option from context: it is not used in reality.
 
    See [rmosolgo/graphql-ruby#3076](https://github.com/rmosolgo/graphql-ruby/pull/3076) for details
+
+### Upgrading notes
+
+ 1. Change method of plugging in of this gem from `use GraphQL::Subscriptions::AnyCableSubscriptions` to `use GraphQL::AnyCable`:
+
+    ```ruby
+    use GraphQL::AnyCable
+    ```
+
+    If you need broadcasting, add `broadcast: true` option and ensure that [Interpreter mode](https://graphql-ruby.org/queries/interpreter.html) is enabled.
+
+    ```ruby
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::AnyCable, broadcast: true, default_broadcastable: true
+    ```
+
+ 2. Enable `handle_legacy_subscriptions` setting for seamless upgrade from previous versions:
+
+    ```sh
+    GRAPHQL_ANYCABLE_HANDLE_LEGACY_SUBSCRIPTIONS=true
+    ```
+
+    Disable or remove this setting when you sure that all clients has re-subscribed (e.g. after `subscription_expiration_seconds` has passed after upgrade) as it imposes small performance penalty.
 
 ## 0.5.0 - 2020-08-26
 

--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -10,8 +10,8 @@ require_relative "graphql/subscriptions/anycable_subscriptions"
 
 module GraphQL
   module AnyCable
-    def self.use(schema)
-      schema.use GraphQL::Subscriptions::AnyCableSubscriptions
+    def self.use(schema, **options)
+      schema.use GraphQL::Subscriptions::AnyCableSubscriptions, **options
     end
 
     module_function

--- a/lib/graphql/anycable/cleaner.rb
+++ b/lib/graphql/anycable/cleaner.rb
@@ -64,10 +64,11 @@ module GraphQL
 
       def clean_topic_fingerprints
         redis.scan_each(match: "#{adapter::FINGERPRINTS_PREFIX}*") do |key|
-          redis.smembers(key).each do |fingerprint|
+          redis.zremrangebyscore(key, '-inf', '0')
+          redis.zmembers(key).each do |fingerprint|
             next if redis.exists?(adapter::SUBSCRIPTIONS_PREFIX + fingerprint)
 
-            redis.srem(key, fingerprint)
+            redis.zrem(key, fingerprint)
           end
         end
       end

--- a/lib/graphql/anycable/cleaner.rb
+++ b/lib/graphql/anycable/cleaner.rb
@@ -65,7 +65,7 @@ module GraphQL
       def clean_topic_fingerprints
         redis.scan_each(match: "#{adapter::FINGERPRINTS_PREFIX}*") do |key|
           redis.zremrangebyscore(key, '-inf', '0')
-          redis.zmembers(key).each do |fingerprint|
+          redis.zrange(key, 0, -1).each do |fingerprint|
             next if redis.exists?(adapter::SUBSCRIPTIONS_PREFIX + fingerprint)
 
             redis.zrem(key, fingerprint)

--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -10,6 +10,7 @@ module GraphQL
 
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
+      attr_config handle_legacy_subscriptions: false
     end
   end
 end

--- a/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
+++ b/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
@@ -5,10 +5,7 @@ require "graphql-anycable"
 namespace :graphql do
   namespace :anycable do
     desc "Clean up stale graphql channels, subscriptions, and events from redis"
-    task clean: %i[clean:channels clean:subscriptions clean:events]
-
-    # Old name that was used earlier
-    task clean_expired_subscriptions: :clean
+    task clean: %i[clean:channels clean:subscriptions clean:events clean:fingerprint_subscriptions clean:topic_fingerprints]
 
     namespace :clean do
       # Clean up old channels
@@ -21,9 +18,19 @@ namespace :graphql do
         GraphQL::AnyCable::Cleaner.clean_subscriptions
       end
 
-      # Clean up subscription_ids from events for expired subscriptions
+      # Clean up legacy subscription_ids from events for expired subscriptions
       task :events do
         GraphQL::AnyCable::Cleaner.clean_events
+      end
+
+      # Clean up subscription_ids from event fingerprints for expired subscriptions
+      task :fingerprint_subscriptions do
+        GraphQL::AnyCable::Cleaner.clean_fingerprint_subscriptions
+      end
+
+      # Clean up fingerprints from event topics. for expired subscriptions
+      task :topic_fingerprints do
+        GraphQL::AnyCable::Cleaner.clean_topic_fingerprints
       end
     end
   end

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -75,7 +75,7 @@ module GraphQL
       def execute_all(event, object)
         execute_legacy(event, object) if config.handle_legacy_subscriptions
 
-        fingerprints = redis.zrevrange(FINGERPRINTS_PREFIX + event.topic, 0, -1)
+        fingerprints = redis.zrange(FINGERPRINTS_PREFIX + event.topic, 0, -1)
         return if fingerprints.empty?
 
         fingerprint_subscription_ids = Hash[fingerprints.zip(

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe GraphQL::AnyCable do
       expect(redis.exists?("graphql-fingerprints::productUpdated:")).to be true
       subject
       expect(redis.exists?("graphql-channel:ohmycables")).to be false
-      expect(redis.exists?("graphql-fingerprints::productUpdated:")).to be false
+      expect(redis.zcard("graphql-fingerprints::productUpdated:")).to be_zero # Seems to be fakeredis bug
       expect(redis.exists?("graphql-subscription:some-truly-random-number")).to be false
     end
   end

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -32,19 +32,24 @@ RSpec.describe GraphQL::AnyCable do
     "some-truly-random-number"
   end
 
+  let(:fingerprint) do
+    ":productUpdated:/SomeSubscription/fBDZmJU1UGTorQWvOyUeaHVwUxJ3T9SEqnetj6SKGXc=/0/RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o="
+  end
+
   before do
     allow(anycable).to receive(:broadcast)
+    allow_any_instance_of(GraphQL::Subscriptions::Event).to receive(:fingerprint).and_return(fingerprint)
   end
 
   it "subscribes channel to stream updates from GraphQL subscription" do
     subject
-    expect(channel).to have_received(:stream_from).with("graphql-subscription:#{subscription_id}")
+    expect(channel).to have_received(:stream_from).with("graphql-subscriptions:#{fingerprint}")
   end
 
   it "broadcasts message when event is being triggered" do
     subject
     AnycableSchema.subscriptions.trigger(:product_updated, {}, { id: 1, title: "foo" })
-    expect(anycable).to have_received(:broadcast).with("graphql-subscription:#{subscription_id}", expected_result)
+    expect(anycable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
   end
 
   context "with multiple subscriptions in one query" do
@@ -61,7 +66,7 @@ RSpec.describe GraphQL::AnyCable do
       it "broadcasts message only for update event" do
         subject
         AnycableSchema.subscriptions.trigger(:product_updated, {}, { id: 1, title: "foo" })
-        expect(anycable).to have_received(:broadcast).with("graphql-subscription:#{subscription_id}", expected_result)
+        expect(anycable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
       end
     end
 
@@ -76,7 +81,7 @@ RSpec.describe GraphQL::AnyCable do
         subject
         AnycableSchema.subscriptions.trigger(:product_created, {}, { id: 1, title: "Gravizapa" })
 
-        expect(anycable).to have_received(:broadcast).with("graphql-subscription:#{subscription_id}", expected_result)
+        expect(anycable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
       end
     end
   end

--- a/spec/graphql/broadcast_spec.rb
+++ b/spec/graphql/broadcast_spec.rb
@@ -43,10 +43,9 @@ RSpec.describe "Broadcasting" do
 
     it "uses broadcasting to resolve query only once" do
       2.times { subscribe(query) }
-      # allow(object).to receive(:title)
       BroadcastSchema.subscriptions.trigger(:post_created, {}, object)
       expect(object).to have_received(:title).once
-      expect(anycable).to have_received(:broadcast).twice
+      expect(anycable).to have_received(:broadcast).once
     end
   end
 
@@ -59,7 +58,6 @@ RSpec.describe "Broadcasting" do
 
     it "resolves query for every client" do
       2.times { subscribe(query) }
-      # allow(object).to receive(:title)
       BroadcastSchema.subscriptions.trigger(:post_created, {}, object)
       expect(object).to have_received(:title).twice
       expect(anycable).to have_received(:broadcast).twice

--- a/spec/graphql/broadcast_spec.rb
+++ b/spec/graphql/broadcast_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
+
+RSpec.describe "Broadcasting" do
+  def subscribe(query)
+    BroadcastSchema.execute(
+      query: query,
+      context: { channel: channel },
+      variables: {},
+      operation_name: "SomeSubscription",
+    )
+  end
+
+  let(:channel) do
+    double
+  end
+
+  let(:object) do
+    double("Post", id: 1, title: "Broadcasting…", actions: %w[Edit Delete])
+  end
+
+  let(:query) do
+    <<~GRAPHQL.strip
+      subscription SomeSubscription { postCreated{ id title } }
+    GRAPHQL
+  end
+
+  let(:anycable) { AnyCable.broadcast_adapter }
+
+  before do
+    allow(channel).to receive(:stream_from)
+    allow(channel).to receive(:params).and_return("channelId" => "ohmycables")
+    allow(anycable).to receive(:broadcast)
+  end
+
+  context "when all clients asks for broadcastable fields only" do
+    let(:query) do
+      <<~GRAPHQL.strip
+        subscription SomeSubscription { postCreated{ id title } }
+      GRAPHQL
+    end
+
+    it "uses broadcasting to resolve query only once" do
+      2.times { subscribe(query) }
+      # allow(object).to receive(:title)
+      BroadcastSchema.subscriptions.trigger(:post_created, {}, object)
+      expect(object).to have_received(:title).once
+      expect(anycable).to have_received(:broadcast).twice
+    end
+  end
+
+  context "when all clients asks for non-broadcastable fields" do
+    let(:query) do
+      <<~GRAPHQL.strip
+        subscription SomeSubscription { postCreated{ id title actions } }
+      GRAPHQL
+    end
+
+    it "resolves query for every client" do
+      2.times { subscribe(query) }
+      # allow(object).to receive(:title)
+      BroadcastSchema.subscriptions.trigger(:post_created, {}, object)
+      expect(object).to have_received(:title).twice
+      expect(anycable).to have_received(:broadcast).twice
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ TESTING_GRAPHQL_RUBY_INTERPRETER =
   end
 
 require_relative "support/graphql_schema"
+require_relative "support/graphql_schema_broadcast"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/graphql_schema_broadcast.rb
+++ b/spec/support/graphql_schema_broadcast.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
+
+class Post < GraphQL::Schema::Object
+  field :id, ID, null: false, broadcastable: true
+  field :title, String, null: true
+  field :actions, [String], null: false, broadcastable: false
+end
+
+class PostCreated < GraphQL::Schema::Subscription
+  payload_type Post
+end
+
+class BroadcastSubscriptionType < GraphQL::Schema::Object
+  field :post_created, subscription: PostCreated
+end
+
+class BroadcastSchema < GraphQL::Schema
+  use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
+  use GraphQL::AnyCable, broadcast: true, default_broadcastable: true
+
+  subscription BroadcastSubscriptionType
+end


### PR DESCRIPTION
Fixes #13 

Documentation: https://graphql-ruby.org/subscriptions/broadcast

Current implementation mimics grapqhl-ruby actioncable implementation from https://github.com/rmosolgo/graphql-ruby/pull/2959 a lot: in actioncable nested hashes are being used to lookup events by topic first and [fingerprint](https://github.com/rmosolgo/graphql-ruby/pull/2959/files#diff-0c23db1a247665896fe010d24fa8349dR56-R69) then. So I implemented a similar two-step lookup of subscriptions by topic and fingerprint. ~AnyCable clients are still subscribed to their own subscriptions and we re-evaluate query once but still broadcast transmit updates individually.~ AnyCable clients are subscribed to event fingerprint-based streams, so now we can evaluate grouped query once and multicast it to clients also at once.