### PR TITLE
Add GraphQL ~> 1.12 to test matrix and allow to use other GraphQL version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         include:
           - ruby: 2.7
+            graphql: '~> 1.12.0'
+            anycable: '~> 1.0.0'
+          - ruby: 2.7
             graphql: '~> 1.11.0'
             anycable: '~> 1.0.0'
             interpreter: yes

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in graphql-anycable.gemspec
 gemspec
 
-gem "graphql",  ENV.fetch("GRAPHQL_RUBY_VERSION", "~> 1.11")
+gem "graphql",  ENV.fetch("GRAPHQL_RUBY_VERSION", "~> 1.12")
 gem "anycable", ENV.fetch("ANYCABLE_VERSION", "~> 1.0")
 
 group :development, :test do

--- a/graphql-anycable.gemspec
+++ b/graphql-anycable.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "anycable",      ">= 0.6.0", "< 2"
   spec.add_dependency "anyway_config", ">= 1.3", "< 3"
-  spec.add_dependency "graphql",       "~> 1.8"
+  spec.add_dependency "graphql",       ">= 1.8", "< 2"
   spec.add_dependency "redis",         ">= 4.2.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
All specs pass on GraphQL 1.12, GRAPHQL_RUBY_INTERPRETER is used by default on this version.

There were also no changes to:
```
  if TESTING_GRAPHQL_RUBY_INTERPRETER
    extend GraphQL::Subscriptions::SubscriptionRoot
  end
```

because https://graphql-ruby.org/api-doc/1.11.6/GraphQL/Subscriptions/SubscriptionRoot.html  `Deprecated. This module is no longer needed.`