### PR TITLE
Add integration tests...

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: "GraphQL-Ruby ${{ matrix.graphql }} (interpreter: ${{ matrix.interpreter }}) with AnyCable ${{ matrix.anycable }} on Ruby ${{ matrix.ruby }}"
+    name: "GraphQL-Ruby ${{ matrix.graphql }} (interpreter: ${{ matrix.interpreter }}, use_client_id: ${{ matrix.client_id }}) on Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -18,42 +18,22 @@ jobs:
         include:
           - ruby: "3.0"
             graphql: '~> 1.12.0'
-            anycable: '~> 1.1.0'
-            interpreter: yes
-          - ruby: "3.0"
-            graphql: '~> 1.12.0'
-            anycable: '~> 1.1.0'
-            interpreter: no
-          - ruby: 2.7
-            graphql: '~> 1.12.0'
-            anycable: '~> 1.1.0'
+            client_id: 'false'
             interpreter: yes
           - ruby: 2.7
             graphql: '~> 1.12.0'
-            anycable: '~> 1.1.0'
-            interpreter: no
-          - ruby: 2.6
-            graphql: '~> 1.11.0'
-            anycable: '~> 1.0.0'
+            client_id: 'false'
             interpreter: yes
           - ruby: 2.6
             graphql: '~> 1.11.0'
-            anycable: '~> 1.0.0'
-            interpreter: no
-          - ruby: 2.5
-            graphql: '~> 1.11.0'
-            anycable: '~> 1.0.0'
-            interpreter: yes
-          - ruby: 2.5
-            graphql: '~> 1.11.0'
-            anycable: '~> 1.0.0'
+            client_id: 'true'
             interpreter: no
     container:
       image: ruby:${{ matrix.ruby }}
       env:
         CI: true
         GRAPHQL_RUBY_VERSION: ${{ matrix.graphql }}
-        ANYCABLE_VERSION: ${{ matrix.anycable }}
+        GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID: ${{ matrix.client_id }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 
 gem "graphql",  ENV.fetch("GRAPHQL_RUBY_VERSION", "~> 1.12")
 gem "anycable", ENV.fetch("ANYCABLE_VERSION", "~> 1.0")
+gem "anycable-rails", github: "anycable/anycable-rails"
 
 group :development, :test do
   gem "pry"

--- a/graphql-anycable.gemspec
+++ b/graphql-anycable.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "fakeredis"
+  spec.add_development_dependency "rack"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/graphql-anycable.gemspec
+++ b/graphql-anycable.gemspec
@@ -31,9 +31,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "graphql",       "~> 1.11"
   spec.add_dependency "redis",         ">= 4.2.0"
 
+  spec.add_development_dependency "anycable-rails"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "rack"
+  spec.add_development_dependency "railties"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -244,7 +244,16 @@ module GraphQL
       def read_subscription_id(channel)
         return channel.instance_variable_get(:@__sid__) if channel.instance_variable_defined?(:@__sid__)
 
-        channel.instance_variable_set(:@__sid__, channel.connection.socket.istate&.[]("sid"))
+        return unless channel.connection.socket.istate
+
+        istate =
+          if channel.connection.socket.istate[channel.identifier]
+            JSON.parse(channel.connection.socket.istate[channel.identifier])
+          else
+            channel.connection.socket.istate
+          end
+
+        channel.instance_variable_set(:@__sid__, istate["sid"])
       end
 
       def write_subscription_id(channel, val)

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -91,12 +91,20 @@ RSpec.describe GraphQL::AnyCable do
 
   describe ".delete_channel_subscriptions" do
     before do
+      GraphQL::AnyCable.config.use_client_provided_uniq_id = false
+    end
+
+    before do
       AnycableSchema.execute(
         query: query,
         context: { channel: channel, subscription_id: subscription_id },
         variables: {},
         operation_name: "SomeSubscription",
       )
+    end
+
+    after do
+      GraphQL::AnyCable.config.use_client_provided_uniq_id = false
     end
 
     let(:redis) { AnycableSchema.subscriptions.redis }

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "anycable/rspec"
+require "rack"
+
+RSpec.shared_context "rpc" do
+  include_context "anycable:rpc:command"
+
+  let(:user) { "john" }
+  let(:schema) { nil }
+  let(:identifiers) { {current_user: "john", schema: schema.to_s} }
+  let(:channel_class) { "GraphqlChannel" }
+  let(:channel_params) { {channelId: rand(1000).to_s} }
+  let(:channel_identifier) { {channel: channel_class}.merge(channel_params) }
+  let(:channel_id) { channel_identifier.to_json }
+
+  let(:handler) { AnyCable::RPC::Handler.new }
+end
+
+# Minimal AnyCable connection implementation
+class FakeConnection
+  class Channel
+    attr_reader :connection, :params, :identifier
+
+    def initialize(connection, identifier, params)
+      @connection = connection
+      @identifier = identifier
+      @params = params
+    end
+
+    def stream_from(broadcasting)
+      connection.socket.subscribe identifier, broadcasting
+    end
+  end
+
+  attr_reader :request, :socket, :identifiers, :subscriptions,
+              :schema
+
+  def initialize(socket, identifiers: nil, subscriptions: nil)
+    @socket = socket
+    @identifiers = identifiers ? JSON.parse(identifiers) : {}
+    @request = Rack::Request.new(socket.env)
+    @schema = Object.const_get(@identifiers["schema"])
+    @subscriptions = subscriptions
+  end
+
+  def handle_channel_command(identifier, command, data)
+    parsed_id = JSON.parse(identifier)
+
+    parsed_id.delete("channel")
+    channel = Channel.new(self, identifier, parsed_id)
+
+    res =
+      case command
+      when "message"
+        data = JSON.parse(data)
+        result = 
+          schema.execute(
+            query: data["query"],
+            context: identifiers.merge(channel: channel),
+            variables: Hash(data["variables"]),
+            operation_name: data["operationName"],
+          )
+
+        transmit(
+          result: result.subscription? ? { data: nil } : result.to_h,
+          more: result.subscription?,
+        )
+      when "unsubscribe"
+        schema.subscriptions.delete_channel_subscriptions(channel)
+        true
+      else
+        raise "Unknown command"
+      end
+    res
+  end
+
+  def transmit(data)
+    socket.transmit data.to_json
+  end
+
+  def identifiers_json
+    @identifiers.to_json
+  end
+
+  def close
+    socket.close
+  end 
+end
+
+AnyCable.connection_factory = ->(socket, **options) { FakeConnection.new(socket, **options) }
+
+RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{spec/integrations/}) do |metadata|
+    metadata[:integration] = true
+  end
+
+  config.include_context "rpc", integration: true
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -90,6 +90,11 @@ end
 
 AnyCable.connection_factory = ->(socket, **options) { FakeConnection.new(socket, **options) }
 
+# Add verbose logging to exceptions
+AnyCable.capture_exception do |ex, method, message|
+  $stdout.puts "RPC ##{method} failed: #{message}\n#{ex}\n#{ex.backtrace.take(5).join("\n")}"
+end
+
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{spec/integrations/}) do |metadata|
     metadata[:integration] = true

--- a/spec/integrations/broadcastable_subscriptions_spec.rb
+++ b/spec/integrations/broadcastable_subscriptions_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
+
+require "integration_helper"
+
+RSpec.describe "broadcastable subscriptions" do
+  let(:schema) { BroadcastSchema }
+
+  let(:query) do
+    <<~GQL
+      subscription postSubscription($id: ID!) {
+        postUpdated(id: $id) {
+          post {
+            title
+          }
+        }
+      }
+    GQL
+  end
+  let(:variables) { {id: "a"} }
+
+  let(:subscription_payload) { {query: query, variables: variables} }
+
+  let(:command) { "message" }
+  let(:data) { {action: "execute", **subscription_payload} }
+
+  subject { handler.handle(:command, request) }
+
+  before { allow(AnyCable.broadcast_adapter).to receive(:broadcast) }
+
+  describe "execute" do
+    it "responds with result" do
+      expect(subject).to be_success
+      expect(subject.transmissions.size).to eq 1
+      expect(subject.transmissions.first).to eq({result: {data: nil}, more: true}.to_json)
+      expect(subject.streams.size).to eq 1
+    end
+
+    specify "streams depends only on query params and the same for equal subscriptions" do
+      expect(subject).to be_success
+      expect(subject.streams.size).to eq 1
+
+      stream_name = subject.streams.first
+
+      # update request context and channelId
+      request.connection_identifiers = identifiers.merge(current_user: "alice").to_json
+      request.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+      expect(response.streams).to eq([stream_name])
+
+      # now update the query param
+      request.data = data.merge(variables: {id: "b"}).to_json
+      request.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+      expect(response.streams.size).to eq 1
+      expect(response.streams.first).not_to eq stream_name
+    end
+  end
+
+  describe "unsubscribe" do
+    let(:redis) { AnycableSchema.subscriptions.redis }
+    let(:config) { GraphQL::AnyCable.config }
+
+    specify "removes subscription from the store" do
+      # first, subscribe to obtain the connection state
+      subscribe_response = handler.handle(:command, request)
+      expect(subscribe_response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(1)
+
+      first_state = subscribe_response.istate
+
+      request.command = "unsubscribe"
+      request.data = ""
+      request.istate = first_state
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(0)
+    end
+
+    specify "creates single entry for similar subscriptions" do
+      # first, subscribe to obtain the connection state
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(1)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+      request_2 = request.dup
+
+      # update request context and channelId
+      request_2.connection_identifiers = identifiers.merge(current_user: "alice").to_json
+      request_2.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+      response_2 = handler.handle(:command, request_2)
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(2)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+      schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).once
+
+      first_state = response.istate
+
+      request.command = "unsubscribe"
+      request.data = ""
+      request.istate = first_state
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(1)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+      schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+
+      second_state = response_2.istate
+
+      request_2.command = "unsubscribe"
+      request_2.data = ""
+      request_2.istate = second_state
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(0)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(0)
+
+      schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+    end
+
+    context "with similar ChannelId and not using ID from client" do
+      let(:config) { GraphQL::AnyCable.config }
+
+      around do |ex|
+        config.use_client_provided_uniq_id.tap do |was_val|
+          config.use_client_provided_uniq_id = false
+          ex.run
+          config.use_client_provided_uniq_id = was_val
+        end
+      end
+
+      specify "creates an entry for each subscription" do
+        # first, subscribe to obtain the connection state
+        subscribe_response = handler.handle(:command, request)
+        expect(subscribe_response).to be_success
+  
+        expect(redis.keys("graphql-subscription:*").size).to eq(1)
+        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+  
+        # update request context
+        request.connection_identifiers = identifiers.merge(current_user: "alice").to_json
+  
+        response = handler.handle(:command, request)
+  
+        expect(redis.keys("graphql-subscription:*").size).to eq(2)
+        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+  
+        istate = response.istate
+  
+        request.command = "unsubscribe"
+        request.data = ""
+        request.istate = istate
+  
+        response = handler.handle(:command, request)
+        expect(response).to be_success
+  
+        expect(redis.keys("graphql-subscription:*").size).to eq(1)
+        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+      end
+    end
+
+    context "without subscription" do
+      let(:data) { nil }
+      let(:command) { "unsubscribe" }
+
+      specify do
+        expect(subject).to be_success
+      end
+    end
+  end
+end

--- a/spec/integrations/per_client_subscriptions_spec.rb
+++ b/spec/integrations/per_client_subscriptions_spec.rb
@@ -1,0 +1,193 @@
+
+# frozen_string_literal: true
+
+require "integration_helper"
+
+RSpec.describe "non-broadcastable subscriptions" do
+  let(:schema) { AnycableSchema }
+
+  let(:query) do
+    <<~GQL
+      subscription postSubscription($id: ID!) {
+        postUpdated(id: $id) {
+          post {
+            title
+          }
+        }
+      }
+    GQL
+  end
+  let(:variables) { {id: "a"} }
+
+  let(:subscription_payload) { {query: query, variables: variables} }
+
+  let(:command) { "message" }
+  let(:data) { {action: "execute", **subscription_payload} }
+
+  subject { handler.handle(:command, request) }
+
+  before { allow(AnyCable.broadcast_adapter).to receive(:broadcast) }
+
+  describe "execute" do
+    it "responds with result" do
+      expect(subject).to be_success
+      expect(subject.transmissions.size).to eq 1
+      expect(subject.transmissions.first).to eq({result: {data: nil}, more: true}.to_json)
+      expect(subject.streams.size).to eq 1
+    end
+
+    specify "creates uniq stream for each subscription" do
+      expect(subject).to be_success
+      expect(subject.streams.size).to eq 1
+
+      all_streams = Set.new(subject.streams)
+
+      # update request channelId
+      request.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+      expect(response.streams.size).to eq 1
+
+      all_streams << response.streams.first
+      expect(all_streams.size).to eq 2
+
+      # now update the query param
+      request.data = data.merge(variables: {id: "b"}).to_json
+      request.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+      expect(response.streams.size).to eq 1
+
+      all_streams << response.streams.first
+      expect(all_streams.size).to eq 3
+    end
+  end
+
+  describe "unsubscribe" do
+    let(:redis) { AnycableSchema.subscriptions.redis }
+
+    specify "removes subscription from the store" do
+      # first, subscribe to obtain the connection state
+      subscribe_response = handler.handle(:command, request)
+      expect(subscribe_response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(1)
+
+      first_state = subscribe_response.istate
+
+      request.command = "unsubscribe"
+      request.data = ""
+      request.istate = first_state
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(0)
+    end
+
+    specify "creates an entry for each subscription" do
+      # first, subscribe to obtain the connection state
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(1)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+      request_2 = request.dup
+
+      # update request context and channelId
+      request_2.connection_identifiers = identifiers.merge(current_user: "alice").to_json
+      request_2.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+      response_2 = handler.handle(:command, request_2)
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(2)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(2)
+
+      schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+
+      first_state = response.istate
+
+      request.command = "unsubscribe"
+      request.data = ""
+      request.istate = first_state
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(1)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+      schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).thrice
+
+      second_state = response_2.istate
+
+      request_2.command = "unsubscribe"
+      request_2.data = ""
+      request_2.istate = second_state
+
+      response = handler.handle(:command, request)
+      expect(response).to be_success
+
+      expect(redis.keys("graphql-subscription:*").size).to eq(0)
+      expect(redis.keys("graphql-subscriptions:*").size).to eq(0)
+
+      schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).thrice
+    end
+
+    context "with similar ChannelId and not using ID from client" do
+      let(:config) { GraphQL::AnyCable.config }
+
+      around do |ex|
+        config.use_client_provided_uniq_id.tap do |was_val|
+          config.use_client_provided_uniq_id = false
+          ex.run
+          config.use_client_provided_uniq_id = was_val
+        end
+      end
+
+      specify "creates an entry for each subscription" do
+        # first, subscribe to obtain the connection state
+        subscribe_response = handler.handle(:command, request)
+        expect(subscribe_response).to be_success
+  
+        expect(redis.keys("graphql-subscription:*").size).to eq(1)
+        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+  
+        # update request context
+        request.connection_identifiers = identifiers.merge(current_user: "alice").to_json
+  
+        response = handler.handle(:command, request)
+  
+        expect(redis.keys("graphql-subscription:*").size).to eq(2)
+        expect(redis.keys("graphql-subscriptions:*").size).to eq(2)
+  
+        istate = response.istate
+  
+        request.command = "unsubscribe"
+        request.data = ""
+        request.istate = istate
+  
+        response = handler.handle(:command, request)
+        expect(response).to be_success
+  
+        expect(redis.keys("graphql-subscription:*").size).to eq(1)
+        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+      end
+    end
+
+    context "without subscription" do
+      let(:data) { nil }
+      let(:command) { "unsubscribe" }
+
+      specify do
+        expect(subject).to be_success
+      end
+    end
+  end
+end

--- a/spec/integrations/per_client_subscriptions_spec.rb
+++ b/spec/integrations/per_client_subscriptions_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "non-broadcastable subscriptions" do
       expect(subject.transmissions.size).to eq 1
       expect(subject.transmissions.first).to eq({result: {data: nil}, more: true}.to_json)
       expect(subject.streams.size).to eq 1
+      expect(subject.istate["sid"]).not_to be_nil
     end
 
     specify "creates uniq stream for each subscription" do

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
+
+require "integration_helper"
+require "rails"
+
+# Stub Rails.root for Anyway Config
+module Rails
+  def self.root
+    Pathname.new(__dir__)
+  end
+end
+
+require "anycable-rails"
+require "anycable/rails/channel_state"
+require "anycable/rails/actioncable/connection"
+
+# Load server to trigger load hooks
+require "action_cable/server"
+require "action_cable/server/base"
+
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user, :schema
+
+    def schema_class
+      schema.constantize
+    end
+  end
+
+  class GraphqlChannel < ActionCable::Channel::Base
+    delegate :schema_class, to: :connection
+
+    def execute(data)
+      result = 
+        schema_class.execute(
+          query: data["query"],
+          context: context,
+          variables: Hash(data["variables"]),
+          operation_name: data["operationName"],
+        )
+
+      transmit(
+        {
+          result: result.subscription? ? { data: nil } : result.to_h,
+          more: result.subscription?
+        }
+      )
+    end
+
+    def unsubscribed
+      schema_class.subscriptions.delete_channel_subscriptions(self)
+    end
+
+    private
+
+    def context
+      {
+        current_user: connection.current_user,
+        channel: self,
+      }
+    end
+  end
+end
+
+RSpec.describe "Rails integration" do
+  let(:schema) { BroadcastSchema }
+  let(:channel_class) { "ApplicationCable::GraphqlChannel" }
+
+  before do
+    allow(AnyCable).to receive(:connection_factory)
+      .and_return(->(socket, **options) { ApplicationCable::Connection.call(socket, **options) })
+  end
+
+  let(:variables) { {id: "a"} }
+
+  let(:subscription_payload) { {query: query, variables: variables} }
+
+  let(:command) { "message" }
+  let(:data) { {action: "execute", **subscription_payload} }
+
+  subject { handler.handle(:command, request) }
+
+  before { allow(AnyCable.broadcast_adapter).to receive(:broadcast) }
+
+  let(:query) do
+    <<~GQL
+      subscription postSubscription($id: ID!) {
+        postUpdated(id: $id) {
+          post {
+            title
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:redis) { AnycableSchema.subscriptions.redis }
+
+  it "execute multiple clients + trigger + disconnect one by one" do
+    # first, subscribe to obtain the connection state
+    response = handler.handle(:command, request)
+    expect(response).to be_success
+
+    expect(redis.keys("graphql-subscription:*").size).to eq(1)
+    expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+    request_2 = request.dup
+
+    # update request context and channelId
+    request_2.connection_identifiers = identifiers.merge(current_user: "alice").to_json
+    request_2.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
+
+    response_2 = handler.handle(:command, request_2)
+
+    expect(redis.keys("graphql-subscription:*").size).to eq(2)
+    expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+    schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+    expect(AnyCable.broadcast_adapter).to have_received(:broadcast).once
+
+    first_state = response.istate
+
+    request.command = "unsubscribe"
+    request.data = ""
+    request.istate = first_state
+
+    response = handler.handle(:command, request)
+    expect(response).to be_success
+
+    expect(redis.keys("graphql-subscription:*").size).to eq(1)
+    expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
+
+    schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+    expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+
+    second_state = response_2.istate
+
+    # Disconnect the second one via #disconnect call
+    disconnect_request = AnyCable::DisconnectRequest.new(
+      identifiers: request_2.connection_identifiers,
+      subscriptions: [request_2.identifier],
+      env: request_2.env
+    )
+
+    disconnect_request.istate[request_2.identifier] = second_state.to_h.to_json
+
+    disconnect_response = handler.handle(:disconnect, disconnect_request)
+    expect(disconnect_response).to be_success
+
+    expect(redis.keys("graphql-subscription:*").size).to eq(0)
+    expect(redis.keys("graphql-subscriptions:*").size).to eq(0)
+
+    schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
+    expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ENV["GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID"] = "false"
+ENV["GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID"] ||= "false"
 
 require "bundler/setup"
 require "graphql/anycable"
@@ -11,7 +11,7 @@ require "yaml"
 TESTING_GRAPHQL_RUBY_INTERPRETER =
   begin
     env_value = ENV["GRAPHQL_RUBY_INTERPRETER"]
-    env_value ? YAML.safe_load(env_value) : false
+    env_value ? YAML.safe_load(env_value) : true
   end
 
 require_relative "support/graphql_schema"
@@ -23,6 +23,9 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/graphql_schema.rb
+++ b/spec/support/graphql_schema.rb
@@ -5,9 +5,37 @@ class Product < GraphQL::Schema::Object
   field :title, String, null: true, hash_key: :title
 end
 
+
+POSTS = [
+  { id: "a", title: "GraphQL is good?", actions: %w[yes no] },
+  { id: "b", title: "Is there life after GraphQL?", actions: %w[no still-no] }
+].freeze
+
+
+class Post < GraphQL::Schema::Object
+  field :id, ID, null: false, broadcastable: true
+  field :title, String, null: true
+  field :actions, [String], null: false, broadcastable: false
+end
+
+class PostUpdated < GraphQL::Schema::Subscription
+  argument :id, ID, required: true
+
+  field :post, Post, null: false
+
+  def subscribe(id:)
+    {post: POSTS.find { |post| post[:id] == id }}
+  end
+
+  def update(*)
+    {post: object}
+  end
+end
+
 class SubscriptionType < GraphQL::Schema::Object
   field :product_created, Product, null: false, resolver_method: :default_resolver
   field :product_updated, Product, null: false, resolver_method: :default_resolver
+  field :post_updated, subscription: PostUpdated
 
   def default_resolver
     return object if context.query.subscription_update?

--- a/spec/support/graphql_schema_broadcast.rb
+++ b/spec/support/graphql_schema_broadcast.rb
@@ -12,8 +12,28 @@ class PostCreated < GraphQL::Schema::Subscription
   payload_type Post
 end
 
+POSTS = [
+  { id: "a", title: "GraphQL is good?", actions: %w[yes no] },
+  { id: "b", title: "Is there life after GraphQL?", actions: %w[no still-no] }
+].freeze
+
+class PostUpdated < GraphQL::Schema::Subscription
+  argument :id, ID, required: true
+
+  field :post, Post, null: false
+
+  def subscribe(id:)
+    {post: POSTS.find { |post| post[:id] == id }}
+  end
+
+  def update(*)
+    {post: object}
+  end
+end
+
 class BroadcastSubscriptionType < GraphQL::Schema::Object
   field :post_created, subscription: PostCreated
+  field :post_updated, subscription: PostUpdated
 end
 
 class BroadcastSchema < GraphQL::Schema


### PR DESCRIPTION
.. And fix a bug when `#unsubscribe` happens before `#execute`.

...And fix a bug with missing `istate` in the disconnect context. 

Also, dropped AnyCable v1.0.x from the build matrix (it's been a while since v1.1 release, let's move on).

(And I think we should get rid of all the `legacy_xxx` stuff, too; and, maybe, switch to interpreter-mode only mode).
