### PR TITLE
Enable GraphQL-Ruby 2.x, stop testing against its non-interpreter mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,27 +10,24 @@ on:
 
 jobs:
   test:
-    name: "GraphQL-Ruby ${{ matrix.graphql }} (interpreter: ${{ matrix.interpreter }}, use_client_id: ${{ matrix.client_id }}) on Ruby ${{ matrix.ruby }}"
+    name: "GraphQL-Ruby ${{ matrix.graphql }} on Ruby ${{ matrix.ruby }} (use_client_id: ${{ matrix.client_id }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - ruby: "3.0"
-            graphql: '~> 1.12.0'
+          - ruby: "3.1"
+            graphql: '~> 2.0.0'
             client_id: 'false'
-            interpreter: yes
-            anycable_rails: '~> 1.2'
+            anycable_rails: '~> 1.3'
+          - ruby: "3.0"
+            graphql: '~> 1.13.0'
+            client_id: 'false'
+            anycable_rails: '~> 1.2.0'
           - ruby: 2.7
             graphql: '~> 1.12.0'
-            client_id: 'false'
-            interpreter: yes
-            anycable_rails: '~> 1.2.0'
-          - ruby: 2.6
-            graphql: '~> 1.11.0'
             client_id: 'true'
-            interpreter: no
-            anycable_rails: '~> 1.0'
+            anycable_rails: '~> 1.1.0'
     container:
       image: ruby:${{ matrix.ruby }}
       env:
@@ -55,6 +52,4 @@ jobs:
           bundle install
           bundle update
       - name: Run RSpec
-        env:
-          GRAPHQL_RUBY_INTERPRETER: ${{ matrix.interpreter }}
         run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ By default all fields are marked as _not safe for broadcasting_. If a subscripti
 
 ```ruby
 class MySchema < GraphQL::Schema
-  use GraphQL::Execution::Interpreter # Required for graphql-ruby before 1.12.4
-  use GraphQL::Analysis::AST
+  use GraphQL::Execution::Interpreter # Required for graphql-ruby before 1.12. Remove it when upgrading to 2.0
+  use GraphQL::Analysis::AST # Required for graphql-ruby before 1.12. Remove it when upgrading to 2.0
   use GraphQL::AnyCable, broadcast: true, default_broadcastable: true
 
   subscription SubscriptionType

--- a/graphql-anycable.gemspec
+++ b/graphql-anycable.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "anycable",      "~> 1.0"
   spec.add_dependency "anyway_config", ">= 1.3", "< 3"
-  spec.add_dependency "graphql",       "~> 1.11"
+  spec.add_dependency "graphql",       ">= 1.11", "< 3"
   spec.add_dependency "redis",         ">= 4.2.0"
 
   spec.add_development_dependency "anycable-rails"

--- a/spec/graphql/broadcast_spec.rb
+++ b/spec/graphql/broadcast_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
-
 RSpec.describe "Broadcasting" do
   def subscribe(query)
     BroadcastSchema.execute(

--- a/spec/integrations/broadcastable_subscriptions_spec.rb
+++ b/spec/integrations/broadcastable_subscriptions_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
-
 require "integration_helper"
 
 RSpec.describe "broadcastable subscriptions" do

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
-
 require "integration_helper"
 require "rails"
 require "action_cable/engine"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,13 +6,6 @@ require "bundler/setup"
 require "graphql/anycable"
 require "fakeredis/rspec"
 require "pry"
-require "yaml"
-
-TESTING_GRAPHQL_RUBY_INTERPRETER =
-  begin
-    env_value = ENV["GRAPHQL_RUBY_INTERPRETER"]
-    env_value ? YAML.safe_load(env_value) : true
-  end
 
 require_relative "support/graphql_schema"
 

--- a/spec/support/graphql_schema.rb
+++ b/spec/support/graphql_schema.rb
@@ -45,23 +45,10 @@ end
 class AnycableSchema < GraphQL::Schema
   use GraphQL::AnyCable
 
-  if TESTING_GRAPHQL_RUBY_INTERPRETER
-    use GraphQL::Execution::Interpreter
-    use GraphQL::Analysis::AST
-  end
-
   subscription SubscriptionType
 end
 
-return unless TESTING_GRAPHQL_RUBY_INTERPRETER # Broadcast requires interpreter
-
-module Interpreted
-  class Post < GraphQL::Schema::Object
-    field :id, ID, null: false, broadcastable: true
-    field :title, String, null: true
-    field :actions, [String], null: false, broadcastable: false
-  end
-
+module Broadcastable
   class PostCreated < GraphQL::Schema::Subscription
     payload_type Post
   end
@@ -81,16 +68,14 @@ module Interpreted
     end
   end
 
-  class BroadcastSubscriptionType < GraphQL::Schema::Object
+  class SubscriptionType < GraphQL::Schema::Object
     field :post_created, subscription: PostCreated
     field :post_updated, subscription: PostUpdated
   end
 end
 
 class BroadcastSchema < GraphQL::Schema
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
   use GraphQL::AnyCable, broadcast: true, default_broadcastable: true
 
-  subscription Interpreted::BroadcastSubscriptionType
+  subscription Broadcastable::SubscriptionType
 end


### PR DESCRIPTION
 - Allow GraphQL-Ruby 2.x in gemspec

 - Add GraphQL-Ruby 2.0.x to test matrix

   As GraphQL-Ruby doesn't follow SemVer it is not safe to rely on minor version compatibility, see their [versioning](https://graphql-ruby.org/development.html#versioning)

 - Stop testing against non-interpreter GraphQL-Ruby

   Interpreter mode is a default since GraphQL-Ruby 1.12 and it is hard to test both opt-in behaviour in 1.11 and opt-out in 1.12 also given that opt-in code was removed in 2.0.

   Because of that removed testing against 1.11 from test matrix