### PR TITLE
Drop handling of client-provided channel identifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: "GraphQL-Ruby ${{ matrix.graphql }} on Ruby ${{ matrix.ruby }} (use_client_id: ${{ matrix.client_id }})"
+    name: "GraphQL-Ruby ${{ matrix.graphql }} on Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -18,15 +18,12 @@ jobs:
         include:
           - ruby: "3.1"
             graphql: '~> 2.0.0'
-            client_id: 'false'
             anycable_rails: '~> 1.3'
           - ruby: "3.0"
             graphql: '~> 1.13.0'
-            client_id: 'false'
             anycable_rails: '~> 1.2.0'
           - ruby: 2.7
             graphql: '~> 1.12.0'
-            client_id: 'true'
             anycable_rails: '~> 1.1.0'
     container:
       image: ruby:${{ matrix.ruby }}
@@ -34,7 +31,6 @@ jobs:
         CI: true
         GRAPHQL_RUBY_VERSION: ${{ matrix.graphql }}
         ANYCABLE_RAILS_VERSION: ${{ matrix.anycable_rails }}
-        GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID: ${{ matrix.client_id }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+- Handling of client-provided channel identifiers. **BREAKING CHANGE**
+
+  Please make sure that you have changed your channel `disconnected` method to pass channel instance to GraphQL-AnyCable's `delete_channel_subscriptions` method.
+  See [release notes for version 1.1.0](https://github.com/anycable/graphql-anycable/releases/tag/v1.1.0) for details.
+
 - Handling of pre-1.0 subscriptions data.
 
   If you're still using version 0.5 or below, please upgrade to 1.0 or 1.1 first with `handle_legacy_subscriptions` setting enabled.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
     ```.env
     GRAPHQL_ANYCABLE_SUBSCRIPTION_EXPIRATION_SECONDS=604800
     GRAPHQL_ANYCABLE_USE_REDIS_OBJECT_ON_CLEANUP=true
-    GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false
     ```
 
  2. YAML configuration files (note that this is `config/graphql_anycable.yml`, *not* `config/anycable.yml`):
@@ -150,7 +149,6 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
     production:
       subscription_expiration_seconds: 300 # 5 minutes
       use_redis_object_on_cleanup: false # For restricted redis installations
-      use_client_provided_uniq_id: false # To avoid problems with non-uniqueness of Apollo channel identifiers
     ```
 
  3. Configuration from your application code:
@@ -193,7 +191,7 @@ As in AnyCable there is no place to store subscription data in-memory, it should
     }
     ```
 
- 4. Channel subscriptions: `graphql-channel:#{channel_id}` set containing identifiers for subscriptions created in ActionCable channel to delete them on client disconnect.
+ 4. Channel subscriptions: `graphql-channel:#{subscription_id}` set containing identifiers for subscriptions created in ActionCable channel to delete them on client disconnect.
 
     ```
     SMEMBERS graphql-channel:17420c6ed9e

--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -10,15 +10,6 @@ module GraphQL
 
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
-      attr_config use_client_provided_uniq_id: true
-
-      on_load do
-        next unless use_client_provided_uniq_id?
-
-        warn "[Deprecated] Using client provided channel uniq IDs could lead to unexpected behaviour, " \
-             " please, set GraphQL::AnyCable.config.use_client_provided_uniq_id = false or GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false, " \
-             " and update the `#unsubscribed` callback code according to the latest docs."
-      end
     end
   end
 end

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -126,11 +126,8 @@ module GraphQL
 
         raise GraphQL::AnyCable::ChannelConfigurationError unless channel
 
-        channel_uniq_id = config.use_client_provided_uniq_id? ? channel.params["channelId"] : subscription_id
-
         # Store subscription_id in the channel state to cleanup on disconnect
-        write_subscription_id(channel, channel_uniq_id)
-
+        write_subscription_id(channel, subscription_id)
 
         events.each do |event|
           channel.stream_from(SUBSCRIPTIONS_PREFIX + event.fingerprint)
@@ -145,14 +142,14 @@ module GraphQL
         }
 
         redis.multi do |pipeline|
-          pipeline.sadd(CHANNEL_PREFIX + channel_uniq_id, subscription_id)
+          pipeline.sadd(CHANNEL_PREFIX + subscription_id, subscription_id)
           pipeline.mapped_hmset(SUBSCRIPTION_PREFIX + subscription_id, data)
           events.each do |event|
             pipeline.zincrby(FINGERPRINTS_PREFIX + event.topic, 1, event.fingerprint)
             pipeline.sadd(SUBSCRIPTIONS_PREFIX + event.fingerprint, subscription_id)
           end
           next unless config.subscription_expiration_seconds
-          pipeline.expire(CHANNEL_PREFIX + channel_uniq_id, config.subscription_expiration_seconds)
+          pipeline.expire(CHANNEL_PREFIX + subscription_id, config.subscription_expiration_seconds)
           pipeline.expire(SUBSCRIPTION_PREFIX + subscription_id, config.subscription_expiration_seconds)
         end
       end
@@ -193,9 +190,10 @@ module GraphQL
       end
 
       # The channel was closed, forget about it and its subscriptions
-      def delete_channel_subscriptions(channel_or_id)
-        # For backward compatibility
-        channel_id = channel_or_id.is_a?(String) ? channel_or_id : read_subscription_id(channel_or_id)
+      def delete_channel_subscriptions(channel)
+        raise(ArgumentError, "Please pass channel instance to #{__method__} in your #unsubscribed method") if channel.is_a?(String)
+
+        channel_id = read_subscription_id(channel)
 
         # Missing in case disconnect happens before #execute
         return unless channel_id

--- a/spec/graphql/broadcast_spec.rb
+++ b/spec/graphql/broadcast_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "Broadcasting" do
 
   before do
     allow(channel).to receive(:stream_from)
-    allow(channel).to receive(:params).and_return("channelId" => "ohmycables")
     allow(anycable).to receive(:broadcast)
   end
 

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -10,8 +10,7 @@ RSpec.shared_context "rpc" do
   let(:schema) { nil }
   let(:identifiers) { {current_user: "john", schema: schema.to_s} }
   let(:channel_class) { "GraphqlChannel" }
-  let(:channel_params) { {channelId: rand(1000).to_s} }
-  let(:channel_identifier) { {channel: channel_class}.merge(channel_params) }
+  let(:channel_identifier) { {channel: channel_class} }
   let(:channel_id) { channel_identifier.to_json }
 
   let(:handler) { AnyCable::RPC::Handler.new }

--- a/spec/integrations/per_client_subscriptions_spec.rb
+++ b/spec/integrations/per_client_subscriptions_spec.rb
@@ -43,9 +43,6 @@ RSpec.describe "non-broadcastable subscriptions" do
 
       all_streams = Set.new(subject.streams)
 
-      # update request channelId
-      request.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
-
       response = handler.handle(:command, request)
       expect(response).to be_success
       expect(response.streams.size).to eq 1
@@ -55,7 +52,6 @@ RSpec.describe "non-broadcastable subscriptions" do
 
       # now update the query param
       request.data = data.merge(variables: {id: "b"}).to_json
-      request.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
 
       response = handler.handle(:command, request)
       expect(response).to be_success
@@ -98,9 +94,8 @@ RSpec.describe "non-broadcastable subscriptions" do
 
       request_2 = request.dup
 
-      # update request context and channelId
+      # update request context
       request_2.connection_identifiers = identifiers.merge(current_user: "alice").to_json
-      request_2.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
 
       response_2 = handler.handle(:command, request_2)
 
@@ -139,47 +134,6 @@ RSpec.describe "non-broadcastable subscriptions" do
 
       schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
       expect(AnyCable.broadcast_adapter).to have_received(:broadcast).thrice
-    end
-
-    context "with similar ChannelId and not using ID from client" do
-      let(:config) { GraphQL::AnyCable.config }
-
-      around do |ex|
-        config.use_client_provided_uniq_id.tap do |was_val|
-          config.use_client_provided_uniq_id = false
-          ex.run
-          config.use_client_provided_uniq_id = was_val
-        end
-      end
-
-      specify "creates an entry for each subscription" do
-        # first, subscribe to obtain the connection state
-        subscribe_response = handler.handle(:command, request)
-        expect(subscribe_response).to be_success
-  
-        expect(redis.keys("graphql-subscription:*").size).to eq(1)
-        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
-  
-        # update request context
-        request.connection_identifiers = identifiers.merge(current_user: "alice").to_json
-  
-        response = handler.handle(:command, request)
-  
-        expect(redis.keys("graphql-subscription:*").size).to eq(2)
-        expect(redis.keys("graphql-subscriptions:*").size).to eq(2)
-  
-        istate = response.istate
-  
-        request.command = "unsubscribe"
-        request.data = ""
-        request.istate = istate
-  
-        response = handler.handle(:command, request)
-        expect(response).to be_success
-  
-        expect(redis.keys("graphql-subscription:*").size).to eq(1)
-        expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
-      end
     end
 
     context "without subscription" do

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -117,9 +117,8 @@ RSpec.describe "Rails integration" do
 
     request_2 = request.dup
 
-    # update request context and channelId
+    # update request context
     request_2.connection_identifiers = identifiers.merge(current_user: "alice").to_json
-    request_2.identifier = channel_identifier.merge(channelId: rand(1000).to_s).to_json
 
     response_2 = handler.handle(:command, request_2)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ENV["GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID"] ||= "false"
-
 require "bundler/setup"
 require "graphql/anycable"
 require "fakeredis/rspec"


### PR DESCRIPTION
This is **breaking change** as clients will have to change their channel's `unsubscribed` method (see [release notes for version 1.1.0](https://github.com/anycable/graphql-anycable/releases/tag/v1.1.0) for details).

By SemVer we will have to bump version to 2.0, but I don't want to :sweat_smile: 