### PR TITLE
Delay the deprecation warning of `use_client_provided_uniq_id` 

### DIFF
--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -11,14 +11,6 @@ module GraphQL
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
       attr_config use_client_provided_uniq_id: true
-
-      on_load do
-        next unless use_client_provided_uniq_id?
-
-        warn "[Deprecated] Using client provided channel uniq IDs could lead to unexpected behaviour, " \
-             " please, set GraphQL::AnyCable.config.use_client_provided_uniq_id = false or GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false, " \
-             " and update the `#unsubscribed` callback code according to the latest docs."
-      end
     end
   end
 end

--- a/lib/graphql/anycable/railtie.rb
+++ b/lib/graphql/anycable/railtie.rb
@@ -9,6 +9,14 @@ module GraphQL
         path = File.expand_path(__dir__)
         Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
       end
+
+      config.after_initialize do
+        if GraphQL::AnyCable.config.use_client_provided_uniq_id?
+          warn "[Deprecated] Using client provided channel uniq IDs could lead to unexpected behaviour, " \
+               "please, set GraphQL::AnyCable.config.use_client_provided_uniq_id = false or GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false, " \
+               "and update the `#unsubscribed` callback code according to the latest docs."
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When setting the `use_client_provided_uniq_id` to `false` through Ruby configuration code the deprecation warning was still issued in our project:

```ruby
GraphQL::AnyCable.config.use_client_provided_uniq_id = false

# or...

GraphQL::AnyCable.configure do |config|
  config.use_client_provided_uniq_id = false
end
```

This happened because the deprecation warning was issued through an `on_load` callback that is invoked when the `GraphQL::AnyCable.config` is initialised. At that time, Anyway is getting settings through sources like ENV variables, but the Ruby configuration code is invoked **afterwards**. At Dext we prefer having this setting in Ruby code.

This solution delays the deprecation warning until the Rails application is initialized.