### PR TITLE
Better `config.use_client_provided_uniq_id` deprecation

### DIFF
--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -11,6 +11,12 @@ require_relative "graphql/subscriptions/anycable_subscriptions"
 module GraphQL
   module AnyCable
     def self.use(schema, **options)
+      if config.use_client_provided_uniq_id?
+        warn "[Deprecated] Using client provided channel uniq IDs could lead to unexpected behaviour, " \
+             "please, set GraphQL::AnyCable.config.use_client_provided_uniq_id = false or GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false, " \
+             "and update the `#unsubscribed` callback code according to the latest docs."
+      end
+
       schema.use GraphQL::Subscriptions::AnyCableSubscriptions, **options
     end
 

--- a/lib/graphql/anycable/railtie.rb
+++ b/lib/graphql/anycable/railtie.rb
@@ -9,14 +9,6 @@ module GraphQL
         path = File.expand_path(__dir__)
         Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
       end
-
-      config.after_initialize do
-        if GraphQL::AnyCable.config.use_client_provided_uniq_id?
-          warn "[Deprecated] Using client provided channel uniq IDs could lead to unexpected behaviour, " \
-               "please, set GraphQL::AnyCable.config.use_client_provided_uniq_id = false or GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false, " \
-               "and update the `#unsubscribed` callback code according to the latest docs."
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Moving this warning to the invocation of `GraphQL::AnyCable.use` makes it issuable outside of Rails, as suggested by @palkan.