### PR TITLE
Store GraphQL query by fingerprint (optimize for broadcasting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,26 +174,36 @@ As in AnyCable there is no place to store subscription data in-memory, it should
     => 1:myStats:/MyStats/fBDZmJU1UGTorQWvOyUeaHVwUxJ3T9SEqnetj6SKGXc=/0/RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o=
     ```
 
- 2. Event subscriptions: `graphql-subscriptions:#{event.fingerptint}` set containing identifiers for all subscriptions for given operation with certain context and arguments (serialized in _topic_). Fingerprints are already scoped by topic.
+ 2. Subscription data: `graphql-fingerprint:#{event.fingerptint}` hash contains everything required to evaluate subscription on trigger and create data for client.
+
+   ```
+   HGETALL graphql-fingerprint:1:myStats:/MyStats/fBDZmJU1UGTorQWvOyUeaHVwUxJ3T9SEqnetj6SKGXc=/0/RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o=
+   => {
+     context:        '{"user_id":1,"user":{"__gid__":"Z2lkOi8vZWJheS1tYWcyL1VzZXIvMQ"}}',
+     variables:      '{}',
+     operation_name: 'MyStats'
+     query_string:   'subscription MyStats { myStatsUpdated { completed total processed __typename } }',
+   }
+   ```
+
+
+ 3. Event subscriptions: `graphql-subscriptions:#{event.fingerptint}` set containing identifiers for all subscriptions for given operation with certain context and arguments (serialized in _topic_). Fingerprints are already scoped by topic.
 
     ```
     SMEMBERS graphql-subscriptions:1:myStats:/MyStats/fBDZmJU1UGTorQWvOyUeaHVwUxJ3T9SEqnetj6SKGXc=/0/RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o=
     => 52ee8d65-275e-4d22-94af-313129116388
     ```
 
- 3. Subscription data: `graphql-subscription:#{subscription_id}` hash contains everything required to evaluate subscription on trigger and create data for client.
+ 4. Subscription data: `graphql-subscription:#{subscription_id}` hash contains everything required to evaluate subscription on trigger and create data for client.
 
     ```
     HGETALL graphql-subscription:52ee8d65-275e-4d22-94af-313129116388
     => {
-      context:        '{"user_id":1,"user":{"__gid__":"Z2lkOi8vZWJheS1tYWcyL1VzZXIvMQ"}}',
-      variables:      '{}',
-      operation_name: 'MyStats'
-      query_string:   'subscription MyStats { myStatsUpdated { completed total processed __typename } }',
+      events: '{"1:myStats:":"1:myStats:/MyStats/fBDZmJU1UGTorQWvOyUeaHVwUxJ3T9SEqnetj6SKGXc=/0/RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o="}',
     }
     ```
 
- 4. Channel subscriptions: `graphql-channel:#{channel_id}` set containing identifiers for subscriptions created in ActionCable channel to delete them on client disconnect.
+ 5. Channel subscriptions: `graphql-channel:#{channel_id}` set containing identifiers for subscriptions created in ActionCable channel to delete them on client disconnect.
 
     ```
     SMEMBERS graphql-channel:17420c6ed9e

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
     ```.env
     GRAPHQL_ANYCABLE_SUBSCRIPTION_EXPIRATION_SECONDS=604800
     GRAPHQL_ANYCABLE_USE_REDIS_OBJECT_ON_CLEANUP=true
+    GRAPHQL_ANYCABLE_HANDLE_LEGACY_SUBSCRIPTIONS=false
     GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false
     ```
 
@@ -150,6 +151,7 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
     production:
       subscription_expiration_seconds: 300 # 5 minutes
       use_redis_object_on_cleanup: false # For restricted redis installations
+      handle_legacy_subscriptions: false # For seamless upgrade from pre-1.3 versions
       use_client_provided_uniq_id: false # To avoid problems with non-uniqueness of Apollo channel identifiers
     ```
 

--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -10,6 +10,7 @@ module GraphQL
 
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
+      attr_config handle_legacy_subscriptions: false
       attr_config use_client_provided_uniq_id: true
     end
   end


### PR DESCRIPTION
Goal: avoid requesting all subscription ids for fingerprint. That might impose too much load without real need for it.

Actually, we don't need to store GraphQL query and variables separately for each subscriber of the same broadcastable query as they will be the same (see https://graphql-ruby.org/subscriptions/broadcast#under-the-hood), non-broadcastable queries will get unique fingerprints, so extra step to get GraphQL query for re-evaluation seems to be redundant here also.

Status:

- [x] Basic implementation (aka proof of concept)
- [ ] Compatibility with older data model
- [ ] Operational stability (expires etc)
- [ ] Real world check
