### PR TITLE
Support empty operation name

### DIFF
--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -140,7 +140,7 @@ module GraphQL
           query_string: query.query_string,
           variables: query.provided_variables.to_json,
           context: @serializer.dump(context.to_h),
-          operation_name: query.operation_name,
+          operation_name: query.operation_name.to_s,
           events: events.map { |e| [e.topic, e.fingerprint] }.to_h.to_json,
         }
 

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -89,6 +89,28 @@ RSpec.describe GraphQL::AnyCable do
     end
   end
 
+  context "with empty operation name" do
+    subject do
+      AnycableSchema.execute(
+        query: query,
+        context: { channel: channel, subscription_id: subscription_id },
+        variables: {},
+        operation_name: nil,
+      )
+    end
+
+    let(:query) do
+      <<~GRAPHQL
+        subscription { productUpdated { id } }
+      GRAPHQL
+    end
+
+    it "subscribes channel to stream updates from GraphQL subscription" do
+      subject
+      expect(channel).to have_received(:stream_from).with("graphql-subscriptions:#{fingerprint}")
+    end
+  end
+
   describe ".delete_channel_subscriptions" do
     before do
       GraphQL::AnyCable.config.use_client_provided_uniq_id = false


### PR DESCRIPTION
**Issue:** an empty operation name causes the error in the redis-client library (dependency of Redis gem). Only relevant to Redis v5.

**Reason:**
Let's check the path from the `graphql-anycable` to `redis-client`:

1. GraphQL::Subscriptions::AnyCableSubscriptions#write_subscription (the fixed method) builds `data` hash with the `operation_name` key;
2. `operation_name` can be nil, because it's not a required attribute, and a subscription without a name is still valid;
3. `graphql-anycable` passes the `data` hash via the `mapped_hmset` method;
4. `mapped_hmset` sends `HMSET` command via `redis_client`;
5.  `redis_client` checks the attributes [here](https://github.com/redis-rb/redis-client/blob/master/lib/redis_client/command_builder.rb#L37) and triggers the error because one of the attributes (`operation_name`) is nil.

[Here](https://github.com/redis-rb/redis-client/issues/87) you can find a reason why `redis-client` doesn't support nil.

The issue is reproducible with Redis v5, you can remove the fix and the following error will be triggered in spec:

```
GraphQL::AnyCable with empty operation name subscribes channel to stream updates from GraphQL subscription
     Failure/Error: pipeline.mapped_hmset(SUBSCRIPTION_PREFIX + subscription_id, data)
     
     TypeError:
       Unsupported command argument type: NilClass
```