### PR TITLE
feat: Add configurable graphql redis_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
     GRAPHQL_ANYCABLE_SUBSCRIPTION_EXPIRATION_SECONDS=604800
     GRAPHQL_ANYCABLE_USE_REDIS_OBJECT_ON_CLEANUP=true
     GRAPHQL_ANYCABLE_USE_CLIENT_PROVIDED_UNIQ_ID=false
+    GRAPHQL_ANYCABLE_REDIS_PREFIX=graphql
     ```
 
  2. YAML configuration files (note that this is `config/graphql_anycable.yml`, *not* `config/anycable.yml`):
@@ -151,6 +152,7 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
       subscription_expiration_seconds: 300 # 5 minutes
       use_redis_object_on_cleanup: false # For restricted redis installations
       use_client_provided_uniq_id: false # To avoid problems with non-uniqueness of Apollo channel identifiers
+      redis_prefix: graphql # You can configure redis_prefix for anycable-graphql subscription prefixes. Default value "graphql"
     ```
 
  3. Configuration from your application code:
@@ -158,6 +160,7 @@ GraphQL-AnyCable uses [anyway_config] to configure itself. There are several pos
     ```ruby
     GraphQL::AnyCable.configure do |config|
       config.subscription_expiration_seconds = 3600 # 1 hour
+      config.redis_prefix = "graphql" # on our side, we add `-` ourselves after the redis_prefix
     end
     ```
 

--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -11,11 +11,7 @@ module GraphQL
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
       attr_config use_client_provided_uniq_id: true
-      attr_config redis_prefix: "graphql-"
-
-      def redis_prefix
-        Thread.current[:graphql_anycable_redis_prefix] || super
-      end
+      attr_config redis_prefix: "graphql"
     end
   end
 end

--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -11,6 +11,11 @@ module GraphQL
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
       attr_config use_client_provided_uniq_id: true
+      attr_config redis_prefix: "graphql-"
+
+      def redis_prefix
+        Thread.current[:graphql_anycable_redis_prefix] || super
+      end
     end
   end
 end

--- a/lib/graphql/anycable/config.rb
+++ b/lib/graphql/anycable/config.rb
@@ -11,7 +11,7 @@ module GraphQL
       attr_config subscription_expiration_seconds: nil
       attr_config use_redis_object_on_cleanup: true
       attr_config use_client_provided_uniq_id: true
-      attr_config redis_prefix: "graphql"
+      attr_config redis_prefix: "graphql" # Here, we set clear redis_prefix without any hyphen. The hyphen is added at the end of this value on our side.
     end
   end
 end

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -241,19 +241,19 @@ module GraphQL
       end
 
       def full_subscription_prefix
-        "#{config.redis_prefix}#{SUBSCRIPTION_PREFIX}"
+        "#{config.redis_prefix}-#{SUBSCRIPTION_PREFIX}"
       end
 
       def full_fingerprints_prefix
-        "#{config.redis_prefix}#{FINGERPRINTS_PREFIX}"
+        "#{config.redis_prefix}-#{FINGERPRINTS_PREFIX}"
       end
 
       def full_subscriptions_prefix
-        "#{config.redis_prefix}#{SUBSCRIPTIONS_PREFIX}"
+        "#{config.redis_prefix}-#{SUBSCRIPTIONS_PREFIX}"
       end
 
       def full_channel_prefix
-        "#{config.redis_prefix}#{CHANNEL_PREFIX}"
+        "#{config.redis_prefix}-#{CHANNEL_PREFIX}"
       end
     end
   end

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -113,7 +113,9 @@ RSpec.describe GraphQL::AnyCable do
 
   describe ".delete_channel_subscriptions" do
     context "with default config.redis-prefix" do
-      before do
+      around do |ex|
+        GraphQL::AnyCable.config.use_client_provided_uniq_id = false
+        ex.run
         GraphQL::AnyCable.config.use_client_provided_uniq_id = false
       end
 
@@ -124,10 +126,6 @@ RSpec.describe GraphQL::AnyCable do
           variables: {},
           operation_name: "SomeSubscription",
           )
-      end
-
-      after do
-        GraphQL::AnyCable.config.use_client_provided_uniq_id = false
       end
 
       let(:redis) { AnycableSchema.subscriptions.redis }
@@ -148,9 +146,15 @@ RSpec.describe GraphQL::AnyCable do
     end
 
     context "with different config.redis-prefix" do
-      before do
+      around do |ex|
+        old_redis_prefix = GraphQL::AnyCable.config.redis_prefix
         GraphQL::AnyCable.config.use_client_provided_uniq_id = false
         GraphQL::AnyCable.config.redis_prefix = "graphql-test"
+
+        ex.run
+
+        GraphQL::AnyCable.config.use_client_provided_uniq_id = false
+        GraphQL::AnyCable.config.redis_prefix = old_redis_prefix
       end
 
       before do
@@ -160,11 +164,6 @@ RSpec.describe GraphQL::AnyCable do
           variables: {},
           operation_name: "SomeSubscription",
           )
-      end
-
-      after do
-        GraphQL::AnyCable.config.use_client_provided_uniq_id = false
-        GraphQL::AnyCable.config.redis_prefix = "graphql"
       end
 
       let(:redis) { AnycableSchema.subscriptions.redis }

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe GraphQL::AnyCable do
     context "with different config.redis-prefix" do
       before do
         GraphQL::AnyCable.config.use_client_provided_uniq_id = false
-        Thread.current[:graphql_anycable_redis_prefix] = "graphql-thread-"
+        GraphQL::AnyCable.config.redis_prefix = "graphql-test"
       end
 
       before do
@@ -164,7 +164,7 @@ RSpec.describe GraphQL::AnyCable do
 
       after do
         GraphQL::AnyCable.config.use_client_provided_uniq_id = false
-        Thread.current[:graphql_anycable_redis_prefix] = "graphql-"
+        GraphQL::AnyCable.config.redis_prefix = "graphql"
       end
 
       let(:redis) { AnycableSchema.subscriptions.redis }
@@ -174,13 +174,13 @@ RSpec.describe GraphQL::AnyCable do
       end
 
       it "removes subscription from redis" do
-        expect(redis.exists?("graphql-thread-subscription:some-truly-random-number")).to be true
-        expect(redis.exists?("graphql-thread-channel:some-truly-random-number")).to be true
-        expect(redis.exists?("graphql-thread-fingerprints::productUpdated:")).to be true
+        expect(redis.exists?("graphql-test-subscription:some-truly-random-number")).to be true
+        expect(redis.exists?("graphql-test-channel:some-truly-random-number")).to be true
+        expect(redis.exists?("graphql-test-fingerprints::productUpdated:")).to be true
         subject
-        expect(redis.exists?("graphql-thread-channel:some-truly-random-number")).to be false
-        expect(redis.exists?("graphql-thread-fingerprints::productUpdated:")).to be false
-        expect(redis.exists?("graphql-thread-subscription:some-truly-random-number")).to be false
+        expect(redis.exists?("graphql-test-channel:some-truly-random-number")).to be false
+        expect(redis.exists?("graphql-test-fingerprints::productUpdated:")).to be false
+        expect(redis.exists?("graphql-test-subscription:some-truly-random-number")).to be false
       end
     end
   end
@@ -241,6 +241,24 @@ RSpec.describe GraphQL::AnyCable do
         GraphQL::AnyCable::ChannelConfigurationError,
         /ActionCable channel wasn't provided in the context for GraphQL query execution!/,
       )
+    end
+  end
+
+  describe ".config" do
+    it "returns the default redis_prefix" do
+      expect(GraphQL::AnyCable.config.redis_prefix).to eq("graphql")
+    end
+
+    context "when changed redis_prefix" do
+      after do
+        GraphQL::AnyCable.config.redis_prefix = "graphql"
+      end
+
+      it "writes a new value to redis_prefix" do
+        GraphQL::AnyCable.config.redis_prefix = "new-graphql"
+
+        expect(GraphQL::AnyCable.config.redis_prefix).to eq("new-graphql")
+      end
     end
   end
 end


### PR DESCRIPTION
Resolve #35

This PR gives the ability to change the Redis prefixes for graphql subscriptions.
We can change `redis_prefix` by config, for example

```
GraphQL::AnyCable.configure do |config|
  config.redis_prefix = "staging-graphql"
end
```


 