### PR TITLE
feat: add ability to fetch subscription stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,14 @@ It will return the response that contains `subscriptions`
   }
 ```
 
-We can set this data to  [Yabeda] for tracking amount of subscriptions
+Also, you can set another `scan_count`, if needed.
+The default value is 1_000
+
+```ruby
+    GraphQL::AnyCable.stats(scan_count: 100)
+```
+
+We can set statistics data to [Yabeda][] for tracking amount of subscriptions
 
 ```ruby
   # config/initializers/metrics.rb

--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -21,8 +21,8 @@ module GraphQL
       schema.use GraphQL::Subscriptions::AnyCableSubscriptions, **options
     end
 
-    def self.stats(include_subscriptions: false)
-      AnyCable::Stats.new(redis: redis, config: config, include_subscriptions: include_subscriptions).collect
+    def self.stats(**options)
+      Stats.new(**options).collect
     end
 
     module_function

--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -6,6 +6,7 @@ require_relative "graphql/anycable/version"
 require_relative "graphql/anycable/cleaner"
 require_relative "graphql/anycable/config"
 require_relative "graphql/anycable/railtie" if defined?(Rails)
+require_relative "graphql/anycable/stats"
 require_relative "graphql/subscriptions/anycable_subscriptions"
 
 module GraphQL
@@ -18,6 +19,10 @@ module GraphQL
       end
 
       schema.use GraphQL::Subscriptions::AnyCableSubscriptions, **options
+    end
+
+    def self.stats(include_subscriptions: false)
+      AnyCable::Stats.new(redis: redis, config: config, include_subscriptions: include_subscriptions).collect
     end
 
     module_function

--- a/lib/graphql/anycable/stats.rb
+++ b/lib/graphql/anycable/stats.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module AnyCable
+    # Calculates  amount of Graphql Redis keys
+    # (graphql-subscription, graphql-fingerprints, graphql-subscriptions, graphql-channel)
+    # Also, calculate the number of subscribers grouped by subscriptions
+    class Stats
+      SCAN_COUNT_RECORDS_AMOUNT = 1_000
+
+      attr_reader :redis, :config, :list_prefixes_keys, :include_subscriptions
+
+      def initialize(redis:, config:, include_subscriptions: false)
+        @redis = redis
+        @config = config
+        @include_subscriptions = include_subscriptions
+        @list_prefix_keys = list_prefixes_keys
+      end
+
+      def collect
+        total_subscriptions_result = {total: {}}
+
+        list_prefixes_keys.each do |name, prefix|
+          total_subscriptions_result[:total][name] = count_by_scan(match: "#{prefix}*")
+        end
+
+        if include_subscriptions
+          total_subscriptions_result[:subscriptions] = group_subscription_stats
+        end
+
+        total_subscriptions_result
+      end
+
+      private
+
+      # Counting all keys, that match the pattern with iterating by count
+      def count_by_scan(match:, count: SCAN_COUNT_RECORDS_AMOUNT)
+        sb_amount = 0
+        cursor = '0'
+
+        loop do
+          cursor, result = redis.scan(cursor, match: match, count: count)
+          sb_amount += result.count
+
+          break if cursor == '0'
+        end
+
+        sb_amount
+      end
+
+      # Calculate subscribes, grouped by subscriptions
+      def group_subscription_stats
+        subscription_groups = {}
+        redis.scan_each(match: "#{list_prefixes_keys[:fingerprints]}*", count: SCAN_COUNT_RECORDS_AMOUNT) do |fingerprint_key|
+          subscription_name = fingerprint_key.gsub(/#{list_prefixes_keys[:fingerprints]}|:/, "")
+          subscription_groups[subscription_name] = 0
+
+          redis.zscan_each(fingerprint_key) do |data|
+            redis.sscan_each("#{list_prefixes_keys[:subscriptions]}#{data[0]}") do |subscription_key|
+              next unless redis.exists?("#{list_prefixes_keys[:subscription]}#{subscription_key}")
+
+              subscription_groups[subscription_name] += 1
+            end
+          end
+        end
+
+        subscription_groups
+      end
+
+      def adapter
+        GraphQL::Subscriptions::AnyCableSubscriptions
+      end
+
+      def list_prefixes_keys
+        {
+          subscription: redis_key(adapter::SUBSCRIPTION_PREFIX),
+          fingerprints: redis_key(adapter::FINGERPRINTS_PREFIX),
+          subscriptions: redis_key(adapter::SUBSCRIPTIONS_PREFIX),
+          channel: redis_key(adapter::CHANNEL_PREFIX)
+        }
+      end
+
+      def redis_key(prefix)
+        "#{config.redis_prefix}-#{prefix}"
+      end
+    end
+  end
+end

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -260,4 +260,12 @@ RSpec.describe GraphQL::AnyCable do
       end
     end
   end
+
+  describe ".stats" do
+    it "calls Graphql::AnyCable::Stats" do
+      allow_any_instance_of(GraphQL::AnyCable::Stats).to receive(:collect)
+
+      described_class.stats
+    end
+  end
 end

--- a/spec/graphql/stats_spec.rb
+++ b/spec/graphql/stats_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphQL::AnyCable::Stats do
+  describe "#collect" do
+    let(:query) do
+      <<~GRAPHQL
+        subscription SomeSubscription {
+          productCreated { id title }
+          productUpdated { id }
+        }
+      GRAPHQL
+    end
+
+    let(:channel) do
+      socket = double("Socket", istate: AnyCable::Socket::State.new({}))
+      connection = double("Connection", anycable_socket: socket)
+      double("Channel", id: "legacy_id", params: { "channelId" => "legacy_id" }, stream_from: nil, connection: connection)
+    end
+
+    let(:subscription_id) do
+      "some-truly-random-number"
+    end
+
+    before do
+      AnycableSchema.execute(
+        query: query,
+        context: { channel: channel, subscription_id: subscription_id },
+        variables: {},
+        operation_name: "SomeSubscription",
+      )
+    end
+
+    let(:redis) { AnycableSchema.subscriptions.redis }
+    let(:config) { GraphQL::AnyCable.config }
+
+    context "when include_subscriptions is false" do
+      subject { described_class.new(redis: redis, config: config) }
+
+      let(:expected_result) do
+        {total: {subscription: 1, fingerprints: 2, subscriptions: 2, channel: 1}}
+      end
+
+      it "returns total stat" do
+        expect(subject.collect).to eq(expected_result)
+      end
+    end
+
+    context "when include_subscriptions is true" do
+      subject { described_class.new(redis: redis, config: config, include_subscriptions: true) }
+
+      let(:expected_result) do
+        {
+          total: {subscription: 1, fingerprints: 2, subscriptions: 2, channel: 1},
+          subscriptions: {
+            "productCreated"=> 1,
+            "productUpdated"=> 1
+          }
+        }
+      end
+
+      it "returns total stat with grouped subscription stats" do
+        expect(subject.collect).to eq(expected_result)
+      end
+    end
+  end
+end

--- a/spec/graphql/stats_spec.rb
+++ b/spec/graphql/stats_spec.rb
@@ -30,12 +30,7 @@ RSpec.describe GraphQL::AnyCable::Stats do
       )
     end
 
-    let(:redis) { AnycableSchema.subscriptions.redis }
-    let(:config) { GraphQL::AnyCable.config }
-
     context "when include_subscriptions is false" do
-      subject { described_class.new(redis: redis, config: config) }
-
       let(:expected_result) do
         {total: {subscription: 1, fingerprints: 2, subscriptions: 2, channel: 1}}
       end
@@ -46,7 +41,7 @@ RSpec.describe GraphQL::AnyCable::Stats do
     end
 
     context "when include_subscriptions is true" do
-      subject { described_class.new(redis: redis, config: config, include_subscriptions: true) }
+      subject { described_class.new(include_subscriptions: true) }
 
       let(:expected_result) do
         {


### PR DESCRIPTION
This PR adds an ability to call `GraphQL::AnyCable.stats`, which will return the subscription statistics.

For calculating specific existing keys in the `Redis` store, we are using `scan_each` with the argument `count`

The default `count` value in `scan_each` is 10. But this value is not suitable.
So, I ran a benchmark and saw that value `1000` would be more suitable for it

```
scan_each COUNT 10     13.623727   3.093805  16.717532 ( 20.424414)
scan_each COUNT 100     4.232060   0.300462   4.532522 (  6.501772)
scan_each COUNT 1000    5.194357   0.058570   5.252927 (  6.935496)
scan_each COUNT 10000   8.821205   0.023022   8.844227 ( 10.486925)
```

The Redis store, before the benchmark, was filled with 500_000 records

Also, if we use the default value `10`, it will make a lot of calls to `Redis`

For calculating subscribes by subscriptions, I decided to each by `100` elements in the `group_subscription_stats` method
