### PR TITLE
Decouple Redis from AnyCable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,7 @@ AllCops:
 
 Style/ArgumentsForwarding:
   Enabled: false
+
+Style/GlobalVars:
+  Exclude:
+    - "spec/**/*.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- Redis subscriptions store configuration has been decoupled from AnyCable, so you can use any broadcasting adapter and configure Redis as you like. [@palkan] ([#44](https://github.com/anycable/graphql-anycable/pull/44))
+
 ## 1.2.0 - 2024-05-07
 
 ### Added

--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -11,33 +11,50 @@ require_relative "graphql/subscriptions/anycable_subscriptions"
 
 module GraphQL
   module AnyCable
-    def self.use(schema, **opts)
-      schema.use(GraphQL::Subscriptions::AnyCableSubscriptions, **opts)
-    end
+    class << self
+      def use(schema, **opts)
+        schema.use(GraphQL::Subscriptions::AnyCableSubscriptions, **opts)
+      end
 
-    def self.stats(**opts)
-      Stats.new(**opts).collect
-    end
+      def stats(**opts)
+        Stats.new(**opts).collect
+      end
 
-    module_function
+      def redis=(connector)
+        @redis_connector = if connector.is_a?(::Proc)
+          connector
+        else
+          ->(&block) { block.call connector }
+        end
+      end
 
-    def redis
-      @redis ||= begin
+      def with_redis(&block)
+        @redis_connector || default_redis_connector
+        @redis_connector.call { |conn| block.call(conn) }
+      end
+
+      def config
+        @config ||= Config.new
+      end
+
+      def configure
+        yield(config) if block_given?
+      end
+
+      private
+
+      def default_redis_connector
         adapter = ::AnyCable.broadcast_adapter
         unless adapter.is_a?(::AnyCable::BroadcastAdapters::Redis)
           raise "Unsupported AnyCable adapter: #{adapter.class}. " \
-                  "graphql-anycable works only with redis broadcast adapter."
+                "Please, configure Redis connector manually:\n\n" \
+                "  GraphQL::AnyCable.configure do |config|\n" \
+                "    config.redis = Redis.new(url: 'redis://localhost:6379/0')\n" \
+                "  end\n"
         end
-        ::AnyCable.broadcast_adapter.redis_conn
+
+        self.redis = ::AnyCable.broadcast_adapter.redis_conn
       end
-    end
-
-    def config
-      @config ||= GraphQL::AnyCable::Config.new
-    end
-
-    def configure
-      yield(config) if block_given?
     end
   end
 end

--- a/lib/graphql-anycable.rb
+++ b/lib/graphql-anycable.rb
@@ -20,6 +20,11 @@ module GraphQL
         Stats.new(**opts).collect
       end
 
+      def redis
+        warn "Usage of `GraphQL::AnyCable.redis` is deprecated. Instead of `GraphQL::AnyCable.redis.whatever` use `GraphQL::AnyCable.with_redis { |redis| redis.whatever }`"
+        @redis ||= with_redis { |conn| conn }
+      end
+
       def redis=(connector)
         @redis_connector = if connector.is_a?(::Proc)
           connector
@@ -30,7 +35,7 @@ module GraphQL
 
       def with_redis(&block)
         @redis_connector || default_redis_connector
-        @redis_connector.call { |conn| block.call(conn) }
+        @redis_connector.call(&block)
       end
 
       def config

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -186,15 +186,13 @@ module GraphQL
 
         with_redis do |redis|
           redis.smembers(redis_key(CHANNEL_PREFIX) + channel_id).each do |subscription_id|
-            delete_subscription(redis, subscription_id)
+            delete_subscription(subscription_id, redis: redis)
           end
           redis.del(redis_key(CHANNEL_PREFIX) + channel_id)
         end
       end
 
-      private
-
-      def delete_subscription(redis, subscription_id)
+      def delete_subscription(subscription_id, redis: AnyCable.redis)
         events = redis.hget(redis_key(SUBSCRIPTION_PREFIX) + subscription_id, :events)
         events = events ? JSON.parse(events) : {}
         fingerprint_subscriptions = {}
@@ -214,6 +212,8 @@ module GraphQL
           end
         end
       end
+
+      private
 
       def read_subscription_id(channel)
         return channel.instance_variable_get(:@__sid__) if channel.instance_variable_defined?(:@__sid__)

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -54,7 +54,8 @@ module GraphQL
     class AnyCableSubscriptions < GraphQL::Subscriptions
       extend Forwardable
 
-      def_delegators :"GraphQL::AnyCable", :redis, :config
+      def_delegators :"GraphQL::AnyCable", :with_redis, :config
+      def_delegators :"::AnyCable", :broadcast
 
       SUBSCRIPTION_PREFIX = "subscription:"  # HASH: Stores subscription data: query, context, …
       FINGERPRINTS_PREFIX = "fingerprints:"  # ZSET: To get fingerprints by topic
@@ -70,16 +71,18 @@ module GraphQL
       # An event was triggered.
       # Re-evaluate all subscribed queries and push the data over ActionCable.
       def execute_all(event, object)
-        fingerprints = redis.zrange(redis_key(FINGERPRINTS_PREFIX) + event.topic, 0, -1)
+        fingerprints = with_redis { |redis| redis.zrange(redis_key(FINGERPRINTS_PREFIX) + event.topic, 0, -1) }
         return if fingerprints.empty?
 
-        fingerprint_subscription_ids = fingerprints.zip(
-          redis.pipelined do |pipeline|
-            fingerprints.map do |fingerprint|
-              pipeline.smembers(redis_key(SUBSCRIPTIONS_PREFIX) + fingerprint)
+        fingerprint_subscription_ids = with_redis do |redis|
+          fingerprints.zip(
+            redis.pipelined do |pipeline|
+              fingerprints.map do |fingerprint|
+                pipeline.smembers(redis_key(SUBSCRIPTIONS_PREFIX) + fingerprint)
+              end
             end
-          end
-        ).to_h
+          ).to_h
+        end
 
         fingerprint_subscription_ids.each do |fingerprint, subscription_ids|
           execute_grouped(fingerprint, subscription_ids, event, object)
@@ -94,7 +97,7 @@ module GraphQL
       def execute_grouped(fingerprint, subscription_ids, event, object)
         return if subscription_ids.empty?
 
-        subscription_id = subscription_ids.find { |sid| redis.exists?(redis_key(SUBSCRIPTION_PREFIX) + sid) }
+        subscription_id = with_redis { |redis| subscription_ids.find { |sid| redis.exists?(redis_key(SUBSCRIPTION_PREFIX) + sid) } }
         return unless subscription_id # All subscriptions has expired but haven't cleaned up yet
 
         result = execute_update(subscription_id, event, object)
@@ -115,7 +118,7 @@ module GraphQL
       # @param result [#to_h] result to send to clients
       def deliver(stream_key, result)
         payload = {result: result.to_h, more: true}.to_json
-        anycable.broadcast(stream_key, payload)
+        broadcast(stream_key, payload)
       end
 
       # Save query to "storage" (in redis)
@@ -141,34 +144,57 @@ module GraphQL
           events: events.map { |e| [e.topic, e.fingerprint] }.to_h.to_json
         }
 
-        redis.multi do |pipeline|
-          pipeline.sadd(redis_key(CHANNEL_PREFIX) + subscription_id, [subscription_id])
-          pipeline.mapped_hmset(redis_key(SUBSCRIPTION_PREFIX) + subscription_id, data)
-          events.each do |event|
-            pipeline.zincrby(redis_key(FINGERPRINTS_PREFIX) + event.topic, 1, event.fingerprint)
-            pipeline.sadd(redis_key(SUBSCRIPTIONS_PREFIX) + event.fingerprint, [subscription_id])
+        with_redis do |redis|
+          redis.multi do |pipeline|
+            pipeline.sadd(redis_key(CHANNEL_PREFIX) + subscription_id, [subscription_id])
+            pipeline.mapped_hmset(redis_key(SUBSCRIPTION_PREFIX) + subscription_id, data)
+            events.each do |event|
+              pipeline.zincrby(redis_key(FINGERPRINTS_PREFIX) + event.topic, 1, event.fingerprint)
+              pipeline.sadd(redis_key(SUBSCRIPTIONS_PREFIX) + event.fingerprint, [subscription_id])
+            end
+            next unless config.subscription_expiration_seconds
+            pipeline.expire(redis_key(CHANNEL_PREFIX) + subscription_id, config.subscription_expiration_seconds)
+            pipeline.expire(redis_key(SUBSCRIPTION_PREFIX) + subscription_id, config.subscription_expiration_seconds)
           end
-          next unless config.subscription_expiration_seconds
-          pipeline.expire(redis_key(CHANNEL_PREFIX) + subscription_id, config.subscription_expiration_seconds)
-          pipeline.expire(redis_key(SUBSCRIPTION_PREFIX) + subscription_id, config.subscription_expiration_seconds)
         end
       end
 
       # Return the query from "storage" (in redis)
       def read_subscription(subscription_id)
-        redis.mapped_hmget(
-          "#{redis_key(SUBSCRIPTION_PREFIX)}#{subscription_id}",
-          :query_string, :variables, :context, :operation_name
-        ).tap do |subscription|
-          next if subscription.values.all?(&:nil?) # Redis returns hash with all nils for missing key
+        with_redis do |redis|
+          redis.mapped_hmget(
+            "#{redis_key(SUBSCRIPTION_PREFIX)}#{subscription_id}",
+            :query_string, :variables, :context, :operation_name
+          ).tap do |subscription|
+            next if subscription.values.all?(&:nil?) # Redis returns hash with all nils for missing key
 
-          subscription[:context] = @serializer.load(subscription[:context])
-          subscription[:variables] = JSON.parse(subscription[:variables])
-          subscription[:operation_name] = nil if subscription[:operation_name].strip == ""
+            subscription[:context] = @serializer.load(subscription[:context])
+            subscription[:variables] = JSON.parse(subscription[:variables])
+            subscription[:operation_name] = nil if subscription[:operation_name].strip == ""
+          end
         end
       end
 
-      def delete_subscription(subscription_id)
+      # The channel was closed, forget about it and its subscriptions
+      def delete_channel_subscriptions(channel)
+        raise(ArgumentError, "Please pass channel instance to #{__method__} in your #unsubscribed method") if channel.is_a?(String)
+
+        channel_id = read_subscription_id(channel)
+
+        # Missing in case disconnect happens before #execute
+        return unless channel_id
+
+        with_redis do |redis|
+          redis.smembers(redis_key(CHANNEL_PREFIX) + channel_id).each do |subscription_id|
+            delete_subscription(redis, subscription_id)
+          end
+          redis.del(redis_key(CHANNEL_PREFIX) + channel_id)
+        end
+      end
+
+      private
+
+      def delete_subscription(redis, subscription_id)
         events = redis.hget(redis_key(SUBSCRIPTION_PREFIX) + subscription_id, :events)
         events = events ? JSON.parse(events) : {}
         fingerprint_subscriptions = {}
@@ -187,27 +213,6 @@ module GraphQL
             pipeline.zremrangebyscore(key, "-inf", "0") if score.value.zero?
           end
         end
-      end
-
-      # The channel was closed, forget about it and its subscriptions
-      def delete_channel_subscriptions(channel)
-        raise(ArgumentError, "Please pass channel instance to #{__method__} in your #unsubscribed method") if channel.is_a?(String)
-
-        channel_id = read_subscription_id(channel)
-
-        # Missing in case disconnect happens before #execute
-        return unless channel_id
-
-        redis.smembers(redis_key(CHANNEL_PREFIX) + channel_id).each do |subscription_id|
-          delete_subscription(subscription_id)
-        end
-        redis.del(redis_key(CHANNEL_PREFIX) + channel_id)
-      end
-
-      private
-
-      def anycable
-        @anycable ||= ::AnyCable.broadcast_adapter
       end
 
       def read_subscription_id(channel)

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe GraphQL::AnyCable do
         )
       end
 
-      let(:redis) { AnycableSchema.subscriptions.with_redis { _1 } }
+      let(:redis) { $redis }
 
       subject do
         AnycableSchema.subscriptions.delete_channel_subscriptions(channel)

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe GraphQL::AnyCable do
     double("Channel", id: "legacy_id", params: {"channelId" => "legacy_id"}, stream_from: nil, connection: connection)
   end
 
-  let(:anycable) { AnyCable.broadcast_adapter }
-
   let(:subscription_id) do
     "some-truly-random-number"
   end
@@ -41,7 +39,7 @@ RSpec.describe GraphQL::AnyCable do
   end
 
   before do
-    allow(anycable).to receive(:broadcast)
+    allow(AnyCable).to receive(:broadcast)
     allow_any_instance_of(GraphQL::Subscriptions::Event).to receive(:fingerprint).and_return(fingerprint)
     allow_any_instance_of(GraphQL::Subscriptions).to receive(:build_id).and_return("ohmycables")
   end
@@ -54,7 +52,7 @@ RSpec.describe GraphQL::AnyCable do
   it "broadcasts message when event is being triggered" do
     subject
     AnycableSchema.subscriptions.trigger(:product_updated, {}, {id: 1, title: "foo"})
-    expect(anycable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
+    expect(AnyCable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
   end
 
   context "with multiple subscriptions in one query" do
@@ -71,7 +69,7 @@ RSpec.describe GraphQL::AnyCable do
       it "broadcasts message only for update event" do
         subject
         AnycableSchema.subscriptions.trigger(:product_updated, {}, {id: 1, title: "foo"})
-        expect(anycable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
+        expect(AnyCable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
       end
     end
 
@@ -86,7 +84,7 @@ RSpec.describe GraphQL::AnyCable do
         subject
         AnycableSchema.subscriptions.trigger(:product_created, {}, {id: 1, title: "Gravizapa"})
 
-        expect(anycable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
+        expect(AnyCable).to have_received(:broadcast).with("graphql-subscriptions:#{fingerprint}", expected_result)
       end
     end
   end
@@ -124,7 +122,7 @@ RSpec.describe GraphQL::AnyCable do
         )
       end
 
-      let(:redis) { AnycableSchema.subscriptions.redis }
+      let(:redis) { AnycableSchema.subscriptions.with_redis { _1 } }
 
       subject do
         AnycableSchema.subscriptions.delete_channel_subscriptions(channel)
@@ -160,7 +158,7 @@ RSpec.describe GraphQL::AnyCable do
         )
       end
 
-      let(:redis) { AnycableSchema.subscriptions.redis }
+      let(:redis) { $redis }
 
       subject do
         AnycableSchema.subscriptions.delete_channel_subscriptions(channel)

--- a/spec/graphql/broadcast_spec.rb
+++ b/spec/graphql/broadcast_spec.rb
@@ -26,11 +26,9 @@ RSpec.describe "Broadcasting" do
     GRAPHQL
   end
 
-  let(:anycable) { AnyCable.broadcast_adapter }
-
   before do
     allow(channel).to receive(:stream_from)
-    allow(anycable).to receive(:broadcast)
+    allow(AnyCable).to receive(:broadcast)
   end
 
   context "when all clients asks for broadcastable fields only" do
@@ -44,7 +42,7 @@ RSpec.describe "Broadcasting" do
       2.times { subscribe(query) }
       BroadcastSchema.subscriptions.trigger(:post_created, {}, object)
       expect(object).to have_received(:title).once
-      expect(anycable).to have_received(:broadcast).once
+      expect(AnyCable).to have_received(:broadcast).once
     end
   end
 
@@ -59,7 +57,7 @@ RSpec.describe "Broadcasting" do
       2.times { subscribe(query) }
       BroadcastSchema.subscriptions.trigger(:post_created, {}, object)
       expect(object).to have_received(:title).twice
-      expect(anycable).to have_received(:broadcast).twice
+      expect(AnyCable).to have_received(:broadcast).twice
     end
   end
 
@@ -70,7 +68,7 @@ RSpec.describe "Broadcasting" do
       GRAPHQL
     end
 
-    let(:redis) { AnycableSchema.subscriptions.redis }
+    let(:redis) { $redis }
 
     it "doesn't fail" do
       3.times { subscribe(query) }
@@ -78,7 +76,7 @@ RSpec.describe "Broadcasting" do
       expect(redis.keys("graphql-subscription:*").size).to eq(2)
       expect { BroadcastSchema.subscriptions.trigger(:post_created, {}, object) }.not_to raise_error
       expect(object).to have_received(:title).once
-      expect(anycable).to have_received(:broadcast).once
+      expect(AnyCable).to have_received(:broadcast).once
     end
   end
 end

--- a/spec/integrations/per_client_subscriptions_spec.rb
+++ b/spec/integrations/per_client_subscriptions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "non-broadcastable subscriptions" do
 
   subject { handler.handle(:command, request) }
 
-  before { allow(AnyCable.broadcast_adapter).to receive(:broadcast) }
+  before { allow(AnyCable).to receive(:broadcast) }
 
   describe "execute" do
     it "responds with result" do
@@ -62,7 +62,7 @@ RSpec.describe "non-broadcastable subscriptions" do
   end
 
   describe "unsubscribe" do
-    let(:redis) { AnycableSchema.subscriptions.redis }
+    let(:redis) { $redis }
 
     specify "removes subscription from the store" do
       # first, subscribe to obtain the connection state
@@ -102,7 +102,7 @@ RSpec.describe "non-broadcastable subscriptions" do
       expect(redis.keys("graphql-subscriptions:*").size).to eq(2)
 
       schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
-      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+      expect(AnyCable).to have_received(:broadcast).twice
 
       first_state = response.istate
 
@@ -117,7 +117,7 @@ RSpec.describe "non-broadcastable subscriptions" do
       expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
 
       schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
-      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).thrice
+      expect(AnyCable).to have_received(:broadcast).thrice
 
       second_state = response_2.istate
 
@@ -132,7 +132,7 @@ RSpec.describe "non-broadcastable subscriptions" do
       expect(redis.keys("graphql-subscriptions:*").size).to eq(0)
 
       schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
-      expect(AnyCable.broadcast_adapter).to have_received(:broadcast).thrice
+      expect(AnyCable).to have_received(:broadcast).thrice
     end
 
     context "without subscription" do

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Rails integration" do
 
   subject { handler.handle(:command, request) }
 
-  before { allow(AnyCable.broadcast_adapter).to receive(:broadcast) }
+  before { allow(AnyCable).to receive(:broadcast) }
 
   let(:query) do
     <<~GQL
@@ -108,7 +108,7 @@ RSpec.describe "Rails integration" do
     GQL
   end
 
-  let(:redis) { AnycableSchema.subscriptions.redis }
+  let(:redis) { $redis }
 
   it "execute multiple clients + trigger + disconnect one by one" do
     # first, subscribe to obtain the connection state
@@ -129,7 +129,7 @@ RSpec.describe "Rails integration" do
     expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
 
     schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
-    expect(AnyCable.broadcast_adapter).to have_received(:broadcast).once
+    expect(AnyCable).to have_received(:broadcast).once
 
     first_state = response.istate
 
@@ -144,7 +144,7 @@ RSpec.describe "Rails integration" do
     expect(redis.keys("graphql-subscriptions:*").size).to eq(1)
 
     schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
-    expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+    expect(AnyCable).to have_received(:broadcast).twice
 
     second_state = response_2.istate
 
@@ -164,6 +164,6 @@ RSpec.describe "Rails integration" do
     expect(redis.keys("graphql-subscriptions:*").size).to eq(0)
 
     schema.subscriptions.trigger(:post_updated, {id: "a"}, POSTS.first)
-    expect(AnyCable.broadcast_adapter).to have_received(:broadcast).twice
+    expect(AnyCable).to have_received(:broadcast).twice
   end
 end

--- a/spec/redis_helper.rb
+++ b/spec/redis_helper.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-REDIS_TEST_DB_URL = "redis://localhost:6379/6"
+REDIS_TEST_DB_URL = ENV.fetch("REDIS_URL", "redis://localhost:6379/6")
 
-def setup_redis_test_db
-  test_url = ENV.fetch("REDIS_URL", REDIS_TEST_DB_URL)
-  channel = AnyCable.broadcast_adapter.channel
-  AnyCable.broadcast_adapter = :redis, {url: test_url, channel: channel}
-end
+channel = AnyCable.broadcast_adapter.channel
 
-setup_redis_test_db
+AnyCable.broadcast_adapter = :redis, {url: REDIS_TEST_DB_URL, channel: channel}
+
+$redis = Redis.new(url: REDIS_TEST_DB_URL)
 
 RSpec.configure do |config|
   config.before do
-    GraphQL::AnyCable.redis.flushdb
+    GraphQL::AnyCable.with_redis { _1.flushdb }
   end
 end

--- a/spec/redis_helper.rb
+++ b/spec/redis_helper.rb
@@ -10,6 +10,6 @@ $redis = Redis.new(url: REDIS_TEST_DB_URL)
 
 RSpec.configure do |config|
   config.before do
-    GraphQL::AnyCable.with_redis { _1.flushdb }
+    GraphQL::AnyCable.with_redis(&:flushdb)
   end
 end


### PR DESCRIPTION
## Context

AnyCable no longer depends on Redis in production, so shouldn't we.

## Changes

- [x] Decoupled Redis from `AnyCable.broadcast_adapter` (and removed all usages of the broadcast adapter)
- [x] Refactored Redis usage to be connection pool-friendly (i.e., `#with_redis { |conn| ... }` instead of `#redis`). Although we do not use a connection pool by default, some users might want to go that way.