### PR TITLE
Remove clean:events from clean_expired_subscriptions.rake

### DIFF
--- a/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
+++ b/lib/graphql/anycable/tasks/clean_expired_subscriptions.rake
@@ -5,7 +5,7 @@ require "graphql-anycable"
 namespace :graphql do
   namespace :anycable do
     desc "Clean up stale graphql channels, subscriptions, and events from redis"
-    task clean: %i[clean:channels clean:subscriptions clean:events clean:fingerprint_subscriptions clean:topic_fingerprints]
+    task clean: %i[clean:channels clean:subscriptions clean:fingerprint_subscriptions clean:topic_fingerprints]
 
     namespace :clean do
       # Clean up old channels


### PR DESCRIPTION
This task was removed [here](https://github.com/anycable/graphql-anycable/commit/736501cedd9820f3c481c6fd3b8da2c1b605f8be#diff-4b393e6236ad0e3d03f634bb699a625dd72daafc883c506b881a72a3d7829fe4L21), but the task wasn't removed from the clean task, so remove it.

Attempting to run `rake graphql:anycable:clean` will fail with:

> Don't know how to build task 'clean:events' (See the list of available tasks with `rake --tasks`)

