### PR TITLE
Fix read_subscription returning hash with nil values

### DIFF
--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -165,12 +165,13 @@ module GraphQL
           redis.mapped_hmget(
             "#{redis_key(SUBSCRIPTION_PREFIX)}#{subscription_id}",
             :query_string, :variables, :context, :operation_name
-          ).tap do |subscription|
-            return if subscription.values.all?(&:nil?) # Redis returns hash with all nils for missing key
+          ).then do |subscription|
+            next if subscription.values.all?(&:nil?) # Redis returns hash with all nils for missing key
 
             subscription[:context] = @serializer.load(subscription[:context])
             subscription[:variables] = JSON.parse(subscription[:variables])
             subscription[:operation_name] = nil if subscription[:operation_name].strip == ""
+            subscription
           end
         end
       end

--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -166,7 +166,7 @@ module GraphQL
             "#{redis_key(SUBSCRIPTION_PREFIX)}#{subscription_id}",
             :query_string, :variables, :context, :operation_name
           ).tap do |subscription|
-            next if subscription.values.all?(&:nil?) # Redis returns hash with all nils for missing key
+            return if subscription.values.all?(&:nil?) # Redis returns hash with all nils for missing key
 
             subscription[:context] = @serializer.load(subscription[:context])
             subscription[:variables] = JSON.parse(subscription[:variables])


### PR DESCRIPTION
Since the upgrade to the 1.3.0 version of this lib, we noticed "No query string was present" errors received on our graphql subscription clients; caused by https://github.com/rmosolgo/graphql-ruby/blob/v2.5.4/lib/graphql/subscriptions.rb#L106 receiving a hash with an nil `query_string` instead of receiving nil directly.

This comes from this change (the `return` makes `read_subscription` return nil, while `next` only causes the block to early return): https://github.com/anycable/graphql-anycable/commit/81c3c4c9231fb625fddac968c666f9e1165f4815#diff-4e11ab0cfb2b97d55c90a6b52d3c59dcc0c649422f3ad1b1e9e30fe8a06bc6fdR163
This PR reverts this small change to handle this case more properly.

I've found however that this still masks a race condition (between finding an existing subscription_id for a fingerprint and reading it, it might have been expired / deleted, which explains why we get these errors; however this prevents other subscriptions from the same fingerprint to receive their notification), but I'll open a separate issue.