### PR TITLE
Fix subscription event delivery when some subscriptions expire

### DIFF
--- a/lib/graphql/subscriptions/anycable_subscriptions.rb
+++ b/lib/graphql/subscriptions/anycable_subscriptions.rb
@@ -102,7 +102,7 @@ module GraphQL
         # Iterate through all subscriptions to find the subscription which:
         # 1. still exists in Redis
         # 2. got a result when updated with the event
-        # This protects in cases where a subscription could expire between checking a subscription exists and
+        # This protects in cases where a subscription could expire between checking a subscription existing and
         # update execution
         # We need only one working subscription, because the result will be shared with all subscribers
         with_redis do |redis|

--- a/spec/graphql/anycable_spec.rb
+++ b/spec/graphql/anycable_spec.rb
@@ -202,9 +202,9 @@ RSpec.describe GraphQL::AnyCable do
 
     it "raises configuration error" do
       expect { subject }.to raise_error(
-                              GraphQL::AnyCable::ChannelConfigurationError,
-                              /ActionCable channel wasn't provided in the context for GraphQL query execution!/
-                            )
+        GraphQL::AnyCable::ChannelConfigurationError,
+        /ActionCable channel wasn't provided in the context for GraphQL query execution!/
+      )
     end
   end
 

--- a/spec/graphql/stats_spec.rb
+++ b/spec/graphql/stats_spec.rb
@@ -2,10 +2,17 @@
 
 RSpec.describe GraphQL::AnyCable::Stats do
   describe "#collect" do
-    let(:query) do
+    let(:created_query) do
       <<~GRAPHQL
-        subscription SomeSubscription {
+        subscription ProductCreatedSubscription {
           productCreated { id title }
+        }
+      GRAPHQL
+    end
+
+    let(:updated_query) do
+      <<~GRAPHQL
+        subscription ProductUpdatedSubscription {
           productUpdated { id }
         }
       GRAPHQL
@@ -23,16 +30,23 @@ RSpec.describe GraphQL::AnyCable::Stats do
 
     before do
       AnycableSchema.execute(
-        query: query,
-        context: {channel: channel, subscription_id: subscription_id},
+        query: created_query,
+        context: {channel: channel, subscription_id: "#{subscription_id}-created"},
         variables: {},
-        operation_name: "SomeSubscription"
+        operation_name: "ProductCreatedSubscription"
+      )
+
+      AnycableSchema.execute(
+        query: updated_query,
+        context: {channel: channel, subscription_id: "#{subscription_id}-updated"},
+        variables: {},
+        operation_name: "ProductUpdatedSubscription"
       )
     end
 
     context "when include_subscriptions is false" do
       let(:expected_result) do
-        {total: {subscription: 1, fingerprints: 2, subscriptions: 2, channel: 1}}
+        {total: {subscription: 2, fingerprints: 2, subscriptions: 2, channel: 2}}
       end
 
       it "returns total stat" do
@@ -45,7 +59,7 @@ RSpec.describe GraphQL::AnyCable::Stats do
 
       let(:expected_result) do
         {
-          total: {subscription: 1, fingerprints: 2, subscriptions: 2, channel: 1},
+          total: {subscription: 2, fingerprints: 2, subscriptions: 2, channel: 2},
           subscriptions: {
             "productCreated" => 1,
             "productUpdated" => 1


### PR DESCRIPTION
Fix #52

Before this fix, if a subscription expired after checking at the existing moment during processing, no events would be delivered to any subscribers
